### PR TITLE
Feature/design fixes

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -266,14 +266,18 @@ class App extends PureComponent {
   }
 
   renderOptions = () => {
-    const { isBitcoinAddrOpened } = this.state;
+    const { isBitcoinAddrOpened, isInvoiceLoaded } = this.state;
+    const optionsClassnames = cx({
+      options: true,
+      'options--hide': isInvoiceLoaded,
+    })
     const bitcoinClassnames = cx({
       'options__bitcoin': true,
       'options__bitcoin--opened': isBitcoinAddrOpened,
     });
 
     return (
-      <div className='options'>
+      <div className={optionsClassnames}>
         <div className='options__wrapper'>
           <div className={bitcoinClassnames}>
             <div className='options__bitcoin-address'>

--- a/src/app.js
+++ b/src/app.js
@@ -237,6 +237,10 @@ class App extends PureComponent {
 
   renderSubmit = () => {
     const { isInvoiceLoaded, text } = this.state;
+    const submitClassnames = cx({
+      submit: true,
+      'submit__close': isInvoiceLoaded,
+    })
     const onClick = () => {
       if (isInvoiceLoaded) {
         this.clearInvoiceDetails();
@@ -248,7 +252,7 @@ class App extends PureComponent {
     return (
       <div
         onClick={onClick}
-        className='submit'
+        className={submitClassnames}
       >
         <img
           alt='Submit'
@@ -306,6 +310,13 @@ class App extends PureComponent {
   }
 
   render() {
+    const { isInvoiceLoaded } = this.state;
+
+    const appColumnClasses = cx({
+      app__column: true,
+      'app__column--invoice-loaded': isInvoiceLoaded,
+    })
+
     return (
       <div className='app'>
         {this.renderOptions()}
@@ -314,7 +325,7 @@ class App extends PureComponent {
           {this.renderInput()}
           {this.renderSubmit()}
         </div>
-        <div className='app__column'>
+        <div className={appColumnClasses}>
           {this.renderInvoiceDetails()}
           {this.renderErrorDetails()}
         </div>

--- a/src/app.js
+++ b/src/app.js
@@ -320,8 +320,10 @@ class App extends PureComponent {
           {this.renderInput()}
           {this.renderSubmit()}
         </div>
-        {this.renderInvoiceDetails()}
-        {this.renderErrorDetails()}
+        <div className='app__column'>
+          {this.renderInvoiceDetails()}
+          {this.renderErrorDetails()}
+        </div>
       </div>
     );
   }

--- a/src/app.js
+++ b/src/app.js
@@ -67,7 +67,11 @@ class App extends PureComponent {
 
   handleChange = (event) => {
     const { target: { value: text } } = event;
-    this.setState(() => ({ text }));
+    this.setState(() => ({
+      text,
+      hasError: false,
+      error: {},
+    }));
   }
 
   handleKeyPress = (event) => {
@@ -90,16 +94,6 @@ class App extends PureComponent {
           <div className='error__message'>
             {error.message}
           </div>
-        </div>
-        <div
-          className='error__clear'
-          onClick={this.clearInvoiceDetails}
-        >
-          <img
-            alt='Clear'
-            src={closeImage}
-            className='error__clear-asset'
-          />
         </div>
       </div>
     );

--- a/src/assets/styles/modules/app.scss
+++ b/src/assets/styles/modules/app.scss
@@ -6,7 +6,7 @@
   align-items: center;
   height: 100%;
   width: 100%;
-  padding: $base-spacing 0;
+  padding: $base-spacing;
 
   @include larger-than(mobile) {
     justify-content: center;
@@ -20,11 +20,22 @@
     position: relative;
     transition: $transition;
     width: 100%;
-    padding: 0 $base-spacing;
 
     @include larger-than(mobile) {
       width: $container-width;
-      padding: 0;
+    }
+  }
+
+  &__column {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: relative;
+    transition: $transition;
+    width: 100%;
+
+    @include larger-than(mobile) {
+      width: $container-width;
     }
   }
 }

--- a/src/assets/styles/modules/app.scss
+++ b/src/assets/styles/modules/app.scss
@@ -27,6 +27,7 @@
   }
 
   &__column {
+    margin-top: 50px;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -36,6 +37,10 @@
 
     @include larger-than(mobile) {
       width: $container-width;
+    }
+    
+    &--invoice-loaded {
+      margin-top: 0;
     }
   }
 }

--- a/src/assets/styles/modules/error.scss
+++ b/src/assets/styles/modules/error.scss
@@ -1,7 +1,7 @@
 // Error
 .error {
-  width: $container-width;
   position: relative;
+  width: 100%;
 
   &__container {
     align-items: center;
@@ -16,35 +16,5 @@
     font-size: $font-small-size;
     font-weight: $font-weight-bold;
     overflow-x: scroll;
-  }
-
-  &__clear {
-    height: $icon-size;
-    width: $icon-size;
-    border-radius: 50%;
-    background: $error-color;
-    margin-left: 2 * $base-spacing;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    position: absolute;
-    right: -100px;
-    top: 0;
-    border: $border;
-
-    &:hover {
-      background: lighten($error-color, 10%);
-
-      .error__clear-asset {
-        opacity: 1;
-      }
-    }
-  }
-
-  &__clear-asset {
-    width: 60%;
-    opacity: 0.6;
   }
 }

--- a/src/assets/styles/modules/error.scss
+++ b/src/assets/styles/modules/error.scss
@@ -13,8 +13,12 @@
 
   &__message {
     color: $text-primary;
-    font-size: $font-small-size;
+    font-size: $font-extra-small-size;
     font-weight: $font-weight-bold;
     overflow-x: scroll;
+
+    @include larger-than(mobile) {
+      font-size: $font-small-size;
+    }
   }
 }

--- a/src/assets/styles/modules/invoice.scss
+++ b/src/assets/styles/modules/invoice.scss
@@ -3,14 +3,17 @@
   background: $background-primary;
   border-radius: $border-radius;
   max-width: $container-width;
+  max-height: 400px;
+  width: 100%;
+
   margin: 0 auto;
-  overflow-x: scroll;
+  overflow: scroll;
   padding: ($base-spacing / 2) 0;
   opacity: 0;
   visibility: hidden;
   border: $border;
   transition: $transition;
-
+  margin-top: 2.2 * $base-spacing;
   &--opened {
     opacity: 1;
     visibility: visible;

--- a/src/assets/styles/modules/invoice.scss
+++ b/src/assets/styles/modules/invoice.scss
@@ -2,18 +2,15 @@
 .invoice {
   background: $background-primary;
   border-radius: $border-radius;
-  max-width: $container-width;
-  max-height: 400px;
   width: 100%;
 
   margin: 0 auto;
-  overflow: scroll;
+  overflow-x: scroll;
   padding: ($base-spacing / 2) 0;
   opacity: 0;
   visibility: hidden;
   border: $border;
   transition: $transition;
-  margin-top: 2.2 * $base-spacing;
   &--opened {
     opacity: 1;
     visibility: visible;

--- a/src/assets/styles/modules/logo.scss
+++ b/src/assets/styles/modules/logo.scss
@@ -4,19 +4,21 @@
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
-  padding: 2 * $base-spacing 0;
+  padding: $base-spacing 0;
   width: 100%;
-  margin-bottom: 2 * $base-spacing + 5;
+  margin-bottom: $base-spacing + 5;
 
   @include larger-than(mobile) {
     align-items: center;
+    padding: 2 * $base-spacing 0;
     padding-bottom: 2 * $base-spacing;
+    margin-bottom: 2 * $base-spacing + 5;
   }
 
   &__title {
     font-weight: $font-weight-bold;
     color: $text-primary;
-    font-size: $font-medium-size;
+    font-size: $font-small-size;
 
     @include larger-than(mobile) {
       font-size: $font-large-size;

--- a/src/assets/styles/modules/logo.scss
+++ b/src/assets/styles/modules/logo.scss
@@ -4,8 +4,9 @@
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
-  padding: 2 * $base-spacing $base-spacing;
+  padding: 2 * $base-spacing 0;
   width: 100%;
+  margin-bottom: 2 * $base-spacing + 5;
 
   @include larger-than(mobile) {
     align-items: center;

--- a/src/assets/styles/modules/options.scss
+++ b/src/assets/styles/modules/options.scss
@@ -44,12 +44,21 @@
   }
 
   &__bitcoin-address {
+    position: absolute;
+    right: -5px;
+    top: -1.5 * $base-spacing;
     opacity: 0;
     visibility: hidden;
-    padding-right: $base-spacing / 2;
+    margin-right: $base-spacing / 2;
     color: #ffffff;
     font-weight: 900;
-    font-size: 14px;
+    font-size: 12px;
+
+    @include larger-than(mobile) {
+      position: relative;
+      padding-right: $base-spacing / 2;
+      font-size: 14px;
+    }
   }
 
   &__bitcoin-icon-wrapper {

--- a/src/assets/styles/modules/options.scss
+++ b/src/assets/styles/modules/options.scss
@@ -11,6 +11,16 @@
     left: auto;
   }
 
+  &--hide {
+    opacity: 0;
+    visibility: hidden;
+
+    @include larger-than(mobile) {
+      opacity: 1;
+      visibility: visible;
+    }
+  }
+
   &__wrapper {
     display: flex;
     flex-direction: row;

--- a/src/assets/styles/modules/options.scss
+++ b/src/assets/styles/modules/options.scss
@@ -66,6 +66,8 @@
 
     @include larger-than(mobile) {
       position: relative;
+      top: auto;
+      right: auto;
       padding-right: $base-spacing / 2;
       font-size: 14px;
     }

--- a/src/assets/styles/modules/submit.scss
+++ b/src/assets/styles/modules/submit.scss
@@ -11,7 +11,7 @@
   justify-content: center;
   border: $border;
   cursor: pointer;
-  bottom: -100px;
+  bottom: -90px;
   right: calc(50% - (#{$icon-size} / 2));
   z-index: 3;
 
@@ -30,5 +30,14 @@
   &__asset {
     width: 60%;
     opacity: 0.6;
+  }
+
+  &__close {
+    bottom: auto;
+    border-radius: none;
+    border: 0;
+    right: 0px;
+    height: 60px;
+    width: 60px;
   }
 }

--- a/src/assets/styles/modules/submit.scss
+++ b/src/assets/styles/modules/submit.scss
@@ -13,6 +13,7 @@
   cursor: pointer;
   bottom: -100px;
   right: calc(50% - (#{$icon-size} / 2));
+  z-index: 3;
 
   @include larger-than(tablet) {
     margin-left: 2 * $base-spacing;


### PR DESCRIPTION
- [x] When the success container is shown, hide the absolutely positioned GitHub and Bitcoin icons from the bottom of the view (check screenshot)
- [x] When the success container is show, it should be moved down BELOW the X (cancel) button it is currently covering it (check screenshot)
- [x] Ensure responsiveness (widest the success container should go is as wide as the input above it)
- [x] Ensure that the user is able to scroll on the page to read all of the information (vertically, as well as horizontally -- inside the container).
- [x] On mobile, the error message should come after the Submit button (arrow)
- [x] Responsive styles to ensure usability and accessibility
- [x] Widest that the error container should go is the same width as the input above.