### PR TITLE
added sample invoice

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -410,6 +410,7 @@ export class App extends PureComponent {
 
           if (key === CALLBACK_KEY) {
             return (
+              <>
               <div key={`${key}-${Math.random()}`} className='invoice__item'>
                 <div className='invoice__item-title'>
                   {formatDetailsKey(key)}
@@ -420,6 +421,19 @@ export class App extends PureComponent {
                   </a>
                 </div>
               </div>
+
+              {decodedInvoice[`minSendable`] ? <div key={`${key}-${Math.random()}`} className='invoice__item'>
+                <div className='invoice__item-title'>
+                  Sample Invoice
+                </div>
+                <div className='invoice__item-value'>
+                  <a href={`${decodedInvoice[key]}?amount=${decodedInvoice[`minSendable`]}`}>
+                    {decodedInvoice[key]}?amount={decodedInvoice[`minSendable`]}
+                  </a>
+                </div>
+              </div> : null}
+
+              </>
             )
           }
 

--- a/src/app.js
+++ b/src/app.js
@@ -382,6 +382,10 @@ export class App extends PureComponent {
             return <></>
           }
 
+          if (key === 'payerData') {
+            return <></>
+          }
+
           if (key === LNURL_TAG_KEY) {
             switch (key) {
               case 'payRequest':


### PR DESCRIPTION
This adds a `sample invoice` field that can be clicked to retrieve an invoice from the lnurlp enpoints, this can make it easier for wallets/services that do not support the spec fetch quick invoices.

![Screenshot from 2021-09-30 12-16-32](https://user-images.githubusercontent.com/3731591/135517048-1e5503c5-dfda-443c-b0b7-5d247372e981.png)

I tested to make sure it doesn't break anything, I hope I didn't miss something.