### PR TITLE
Add check for LUD-18 field payerData

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -29,6 +29,7 @@ import {
   TIMESTAMP_STRING_KEY,
   CALLBACK_KEY,
   LNURL_TAG_KEY,
+  PAYER_DATA,
 } from './constants/keys';
 
 // Styles
@@ -473,6 +474,10 @@ export class App extends PureComponent {
             });
 
             return toRender;
+          }
+
+          if (key === PAYER_DATA) {
+            return <></>
           }
 
           return (

--- a/src/constants/keys.js
+++ b/src/constants/keys.js
@@ -46,3 +46,4 @@ export const MAX_WITHDRAWABLE_KEY = 'minWithdrawable';
 export const MIN_WITHDRAWABLE_KEY = 'minWithdrawable';
 export const LN_ADDRESS_DOMAIN_KEY = 'domain';
 export const LN_ADDRESS_USERNAME_KEY = 'username';
+export const PAYER_DATA = 'payerData';


### PR DESCRIPTION
When we try to parse a payRequest response that has support for the [LUD-18](https://github.com/lnurl/luds/blob/luds/18.md) "payerData" field, the renderLNURLDetails function fails. Try using any Alby LN address to test this.

This PR simpy adds a check for the "payerData" field and returns an empty JSX element. I tried to figure out a way to render these nested details properly but after a while I just gave up. I don't have too much experience with frontend dev/design. This change fixes the error at least, then hopefully someone else can figure out a good way to render these details on the website as well.

Fixes #85 