### PR TITLE
feature: allow unknown network types

### DIFF
--- a/src/lib/bolt11.js
+++ b/src/lib/bolt11.js
@@ -758,16 +758,13 @@ function decode (paymentRequest, network) {
   }
 
   let bech32Prefix = prefixMatches[1]
-  let coinNetwork, coinType
+  let coinType = 'unknown'
+  let coinNetwork
   if (BECH32CODES[bech32Prefix]) {
     coinType = BECH32CODES[bech32Prefix]
     coinNetwork = BITCOINJS_NETWORK_INFO[coinType]
   } else if (network && network.bech32) {
-    coinType = 'unknown'
     coinNetwork = network
-  }
-  if (!coinNetwork || coinNetwork.bech32 !== bech32Prefix) {
-    throw new Error('Unknown coin bech32 prefix')
   }
 
   let value = prefixMatches[2]


### PR DESCRIPTION
I ran into an issue decoding a mutinynet invoice, it throws if it's not one of the known networks. This is kinda unnecessary since it can parse it no problem even if it's not an enumerated network. Also closes #78.

<img width="752" alt="Screenshot 2023-06-29 at 11 02 08 AM" src="https://github.com/andrerfneves/lightning-decoder/assets/649992/b965a284-3e17-457d-b15b-be8ac62bc488">
