### PR TITLE
feature: Add fallback scheme support (LUD-01)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -577,8 +577,12 @@ export class App extends PureComponent {
       if (Object.is(value, null)) return;
 
       let text = value;
-      if (value.includes('lightning')) {
+      if (value.includes('lightning:')) {
         text = value.split('lightning:')[1];
+      }
+
+      if (value.includes('lightning=')) {
+        text = value.split('lightning=')[1];
       }
 
       this.getInvoiceDetails(text);

--- a/src/utils/invoices.js
+++ b/src/utils/invoices.js
@@ -37,14 +37,17 @@ export const parseInvoice = async (invoice: string) => {
     }
   }
 
-  // Check if Invoice has `lightning` or `lnurl` prefixes
-  // (9 chars + the `:` or `=` chars) --> 10 characters total
-  const hasLightningPrefix = lcInvoice.indexOf(`${LIGHTNING_SCHEME}:`) !== -1;
-  if (hasLightningPrefix) {
-    // Remove the `lightning` prefix
-    requestCode = lcInvoice.slice(10, lcInvoice.length);
+  // Check if Invoice has `lightning:` or `lightning=` prefix
+  // and remove the prefix and before, so string starts with the invoice
+  if(lcInvoice.includes(`${LIGHTNING_SCHEME}:`)) {
+    requestCode = lcInvoice.split(`${LIGHTNING_SCHEME}:`)[1];
   }
 
+  if(lcInvoice.includes(`${LIGHTNING_SCHEME}=`)) {
+    requestCode = lcInvoice.split(`${LIGHTNING_SCHEME}=`)[1];
+  }
+
+  // Check if Invoice has `lnurl` prefix
   // (5 chars + the `:` or `=` chars) --> 6 characters total
   const hasLNURLPrefix = lcInvoice.indexOf(`${LNURL_SCHEME}:`) !== -1;
   if (hasLNURLPrefix) {


### PR DESCRIPTION
Adding support for Fallback scheme as per [LNURL documentation](https://github.com/lnurl/luds/blob/luds/01.md#fallback-scheme). Currently [lightning-decoder](https://github.com/andrerfneves/lightning-decoder) does not support this kind of urls, this PR aims to fix that for the input and the camera reader. 

Please note that this standard is widely used in the wild, like for example: SPAR Supermarkets in Switzerland, it would be nice if you can consider this PR.

https://cointelegraph.com/news/spar-store-zug-switzerland-bitcoin-payments-lightning-network
https://youtu.be/Qu5VE2JhF54?si=_3DOgKGa7dpm7ArS

**Examples of new supported strings/QR codes:**

https://app.dfx.swiss/pl/?lightning=LNURL1DP68GURN8GHJ7CTSDYHXGENC9EEHW6TNWVHHVVF0D3H82UNVWQHHQMZLVFJK2ERYVG6RZCMYX33RVEPEV5YEJ9WT

<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/6d5a2b2c-e6c6-4f90-9c95-1e5964b62459" />


**Other references**
https://github.com/SamSamskies/lnurlpay/pull/36