### PR TITLE
Refactor frontend to shadcn UI primitives with Tailwind and upgrade React/deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,28 +8,32 @@
   },
   "license": "MIT",
   "dependencies": {
-    "bech32": "^1.1.3",
-    "bitcoinjs-lib": "^5.1.6",
-    "bn.js": "^5.0.0",
-    "buffer": "^5.4.3",
-    "classnames": "^2.2.6",
+    "@radix-ui/react-dialog": "latest",
+    "@radix-ui/react-slot": "latest",
+    "bech32": "latest",
+    "bitcoinjs-lib": "latest",
+    "bn.js": "latest",
+    "buffer": "latest",
+    "class-variance-authority": "latest",
+    "clsx": "latest",
     "coininfo": "https://github.com/cryptocoinjs/coininfo#dc3e6cc59e593ee7dbeb7c993485706e72d32743",
-    "date-fns": "^2.1.0",
-    "eslint": "^5.16.0",
-    "lodash": "^4.17.15",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
-    "react-ga": "^2.6.0",
-    "react-qr-reader": "^2.2.1",
-    "react-scripts": "3.1.1",
-    "safe-buffer": "^5.2.0",
-    "sass": "^1.37.5",
-    "secp256k1": "^3.7.1",
-    "serve": "^11.1.0"
+    "date-fns": "latest",
+    "lodash": "latest",
+    "lucide-react": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "react-ga": "latest",
+    "react-qr-reader": "latest",
+    "react-scripts": "latest",
+    "safe-buffer": "latest",
+    "secp256k1": "latest",
+    "serve": "latest",
+    "tailwind-merge": "latest",
+    "tailwindcss-animate": "latest"
   },
   "scripts": {
-    "start": "export NODE_OPTIONS=--openssl-legacy-provider && react-scripts start",
-    "build": "export NODE_OPTIONS=--openssl-legacy-provider && react-scripts build",
+    "start": "react-scripts start",
+    "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "deploy": "npm run build && cd build && now"
@@ -49,7 +53,10 @@
     "bitcoin"
   ],
   "devDependencies": {
-    "node": "^18.9.0",
-    "eslint": "^6.1.0"
+    "autoprefixer": "latest",
+    "eslint": "latest",
+    "node": "latest",
+    "postcss": "latest",
+    "tailwindcss": "latest"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app.js
+++ b/src/app.js
@@ -1,14 +1,7 @@
 // Core Libs & Utils
-import React, { PureComponent } from 'react';
+import React, { useEffect, useState } from 'react';
 import QrReader from 'react-qr-reader';
-import cx from 'classnames';
-
-// Assets
-import boltImage from './assets/images/bolt.png';
-import arrowImage from './assets/images/arrow.svg';
-import closeImage from './assets/images/close.svg';
-import qrcodeImage from './assets/images/qrcode.png';
-import githubImage from './assets/images/github.svg';
+import { Github, QrCode, RotateCcw, Search, Zap } from 'lucide-react';
 
 // Utils
 import { formatDetailsKey } from './utils/keys';
@@ -31,630 +24,466 @@ import {
   LNURL_TAG_KEY,
 } from './constants/keys';
 
-// Styles
-import './assets/styles/main.scss';
+import { Alert, AlertDescription, AlertTitle } from './components/ui/alert';
+import { Badge } from './components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from './components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from './components/ui/dialog';
+import { Button } from './components/ui/button';
+import { Input } from './components/ui/input';
 
 const INITIAL_STATE = {
   text: '',
-  error: {},
-  hasError: false,
+  error: null,
   decodedInvoice: {},
+  isLNURL: false,
   isLNAddress: false,
   isQRCodeOpened: false,
   isInvoiceLoaded: false,
-  isBitcoinAddrOpened: false,
 };
 
-export class App extends PureComponent {
-  state = INITIAL_STATE;
+export function App() {
+  const [text, setText] = useState(INITIAL_STATE.text);
+  const [error, setError] = useState(INITIAL_STATE.error);
+  const [decodedInvoice, setDecodedInvoice] = useState(INITIAL_STATE.decodedInvoice);
+  const [isLNURL, setIsLNURL] = useState(INITIAL_STATE.isLNURL);
+  const [isLNAddress, setIsLNAddress] = useState(INITIAL_STATE.isLNAddress);
+  const [isQRCodeOpened, setIsQRCodeOpened] = useState(INITIAL_STATE.isQRCodeOpened);
+  const [isInvoiceLoaded, setIsInvoiceLoaded] = useState(INITIAL_STATE.isInvoiceLoaded);
 
-  componentDidMount() {
+  useEffect(() => {
     const invoiceOnURLParam = window.location.pathname;
-
-    // Remove first `/` from pathname
     const cleanInvoice = invoiceOnURLParam.split('/')[1];
     if (cleanInvoice && cleanInvoice !== '') {
-      this.setState(() => ({ text: cleanInvoice }));
-      this.getInvoiceDetails(cleanInvoice);
+      setText(cleanInvoice);
+      getInvoiceDetails(cleanInvoice);
     }
-  }
+  }, []);
 
-  clearInvoiceDetails = () => {
-    // Reset URL address
+  const clearInvoiceDetails = () => {
     const currentOrigin = window.location.origin;
     window.history.pushState({}, null, `${currentOrigin}`);
 
-    this.setState(() => ({
-      ...INITIAL_STATE,
-    }));
+    setText(INITIAL_STATE.text);
+    setError(INITIAL_STATE.error);
+    setDecodedInvoice(INITIAL_STATE.decodedInvoice);
+    setIsLNURL(INITIAL_STATE.isLNURL);
+    setIsLNAddress(INITIAL_STATE.isLNAddress);
+    setIsQRCodeOpened(INITIAL_STATE.isQRCodeOpened);
+    setIsInvoiceLoaded(INITIAL_STATE.isInvoiceLoaded);
   };
 
-  getInvoiceDetails = async (text) => {
-    // If this returns null is because there is no invoice to parse
-    if (!text) {
-      return this.setState(() => ({
-        hasError: true,
-        decodedInvoice: {},
-        isInvoiceLoaded: false,
-        error: { message: 'Please enter a valid request or address and try again.'},
-      }));
+  const setErrorState = (message) => {
+    setError({ message });
+    setDecodedInvoice({});
+    setIsInvoiceLoaded(false);
+  };
+
+  const getInvoiceDetails = async (textValue) => {
+    if (!textValue) {
+      return setErrorState('Please enter a valid request or address and try again.');
     }
 
     try {
       let response;
-      const parsedInvoiceResponse = await parseInvoice(text);
+      const parsedInvoiceResponse = await parseInvoice(textValue);
 
-      // If this returns null is because there is no invoice to parse
       if (!parsedInvoiceResponse) {
-        return this.setState(() => ({
-          hasError: true,
-          decodedInvoice: {},
-          isInvoiceLoaded: false,
-          error: { message: 'Please enter a valid request or address and try again.'},
-        }));
+        return setErrorState('Please enter a valid request or address and try again.');
       }
 
-      const { isLNURL, data, error, isLNAddress } = parsedInvoiceResponse;
+      const { isLNURL: parsedIsLNURL, data, error: parseError, isLNAddress: parsedIsLNAddress } = parsedInvoiceResponse;
 
-      // If an error comes back from a nested operation in parsing it must
-      // propagate back to the end user
-      if (error && error.length > 0) {
-        return this.setState(() => ({
-          hasError: true,
-          decodedInvoice: {},
-          isInvoiceLoaded: false,
-          error: { message: error },
-        }));
+      if (parseError && parseError.length > 0) {
+        return setErrorState(parseError);
       }
 
-      // If data is null it means the parser could not understand the invoice
       if (!data) {
-        return this.setState(() => ({
-          hasError: true,
-          decodedInvoice: {},
-          isInvoiceLoaded: false,
-          error: { message: 'Could not parse/understand this invoice or request. Please try again.'},
-        }));
+        return setErrorState('Could not parse/understand this invoice or request. Please try again.');
       }
 
-      // Handle LNURLs differently
-      if (isLNURL) {
-        // If this is a Lightning Address, the contents have already been fetched
-        if (isLNAddress) {
+      if (parsedIsLNURL) {
+        if (parsedIsLNAddress) {
           response = data;
         } else {
-          // Otherwise this is an LNURL ready to be fetched
           response = await data;
         }
       } else {
-        // Handle normal invoices
         response = data;
       }
 
       if (response) {
-        // On successful response, set the request content on the addressbar
-        // if there isn't one already in there from before (user-entered)
         const currentUrl = window.location;
         const currentOrigin = window.location.origin;
         const currentPathname = window.location.pathname;
         const hasPathnameAlready = currentPathname && currentPathname !== '';
 
-        // If there's a pathname already, we can just remove it and let the
-        // new pathname be entered
         if (hasPathnameAlready) {
           window.history.pushState({}, null, `${currentOrigin}`);
         }
 
-        window.history.pushState({}, null, `${currentUrl}${text}`);
+        window.history.pushState({}, null, `${currentUrl}${textValue}`);
 
-        this.setState(() => ({
-          isLNURL,
-          error: {},
-          isLNAddress,
-          hasError: false,
-          isInvoiceLoaded: true,
-          decodedInvoice: response,
-        }));
+        setIsLNURL(parsedIsLNURL);
+        setError(null);
+        setIsLNAddress(parsedIsLNAddress);
+        setIsInvoiceLoaded(true);
+        setDecodedInvoice(response);
       }
-    } catch(error) {
-      this.setState(() => ({
-        error: error,
-        hasError: true,
-        decodedInvoice: {},
-        isInvoiceLoaded: false,
-      }));
+    } catch (caughtError) {
+      setError(caughtError);
+      setDecodedInvoice({});
+      setIsInvoiceLoaded(false);
     }
-  }
+  };
 
-  handleChange = (event) => {
-    const { target: { value: text } } = event;
+  const handleChange = (event) => {
+    const { target: { value } } = event;
+    setText(value);
+    setError(null);
+  };
 
-    this.setState(() => ({
-      text,
-      error: {},
-      hasError: false,
-    }));
-  }
-
-  handleKeyPress = (event) => {
-    const { text } = this.state;
-
+  const handleKeyPress = (event) => {
     if (event.key === 'Enter') {
-      this.getInvoiceDetails(text);
+      getInvoiceDetails(text);
     }
-  }
+  };
 
-  handleQRCode = () => this.setState(prevState => ({
-    isQRCodeOpened: !prevState.isQRCodeOpened
-  }))
+  const handleScan = (value) => {
+    if (Object.is(value, null)) return;
 
-  renderErrorDetails = () => {
-    const { hasError, error } = this.state;
+    let nextText = value;
+    if (value.includes('lightning')) {
+      nextText = value.split('lightning:')[1];
+    }
 
-    if (!hasError) return null;
+    getInvoiceDetails(nextText);
+    setIsQRCodeOpened(false);
+    setText(nextText);
+  };
 
-    return (
-      <div className='error'>
-        <div className='error__container'>
-          <div className='error__message'>
-            {error.message}
-          </div>
-        </div>
+  const handleError = (qrError) => {
+    setError(qrError);
+    setIsInvoiceLoaded(false);
+    setIsQRCodeOpened(false);
+  };
+
+  const renderNestedItem = (label, value) => (
+    <div key={label} className="flex flex-col gap-1 rounded-md border border-border/70 bg-background/60 p-3">
+      <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {formatDetailsKey(label)}
       </div>
-    );
-  }
+      <div className="text-sm text-foreground break-words">{value}</div>
+    </div>
+  );
 
-  renderInput = () => {
-    const { text } = this.state;
-
-    return (
-      <div className='input'>
-        <img
-          alt='Lightning'
-          src={boltImage}
-          className='input__asset'
-        />
-        <input
-          value={text}
-          className='input__text'
-          onChange={this.handleChange}
-          onKeyPress={this.handleKeyPress}
-          placeholder={APP_INPUT_PLACEHOLDER}
-          autoFocus
-        />
-      </div>
-    );
-  }
-
-  renderInvoiceDetails = () => {
-    const { decodedInvoice, isInvoiceLoaded } = this.state;
-    const invoiceContainerClassnames = cx(
-      'invoice',
-      { 'invoice--opened': isInvoiceLoaded },
-    );
-
-    const invoiceDetails = Object.keys(decodedInvoice)
-      .map((key) => {
-        switch (key) {
-          case COMPLETE_KEY:
-            return null;
-          case TAGS_KEY:
-            return this.renderInvoiceInnerItem(key);
-          case TIMESTAMP_STRING_KEY:
-            return this.renderInvoiceItem(
-              key,
-              TIMESTAMP_STRING_KEY,
-            );
-          default:
-            return this.renderInvoiceItem(key);
-        }
-      });
-
-    return !isInvoiceLoaded ? null : (
-      <div className={invoiceContainerClassnames}>
-        {invoiceDetails}
-      </div>
-    );
-  }
-
-  renderInvoiceInnerItem = (key) => {
-    const { decodedInvoice } = this.state;
+  const renderInvoiceInnerItems = (key) => {
     const tags = decodedInvoice[key];
 
-    const renderTag = (tag) => (
-      typeof tag.data !== 'string' &&
-      typeof tag.data !== 'number'
-    ) ? renderNestedTag(tag) : renderNormalTag(tag);
-
-    const renderNestedItem = (label, value) => (
-      <div
-        key={label}
-        className='invoice__nested-item'
-      >
-        <div className='invoice__nested-title'>
-          {formatDetailsKey(label)}
-        </div>
-        <div className='invoice__nested-value'>
-          {value}
-        </div>
-      </div>
-    );
-
     const renderNestedTag = (tag) => (
-      <div key={tag.tagName} className='invoice__item invoice__item--nested'>
-        <div className='invoice__item-title'>
+      <div key={tag.tagName} className="space-y-3 rounded-lg border border-border bg-background/40 p-4">
+        <div className="text-sm font-semibold text-foreground">
           {formatDetailsKey(tag.tagName)}
         </div>
-        <div className='invoice__item-value invoice__item-value--nested'>
-          {/* Strings */}
+        <div className="space-y-3">
           {typeof tag.data === 'string' && (
-            <div className='invoice__nested-value'>
-              {tag.data}
-            </div>
+            <div className="text-sm text-foreground break-words">{tag.data}</div>
           )}
-          {/* Array of Objects */}
-          {Array.isArray(tag.data) && tag.data.map((item) => (
-            <>
+          {Array.isArray(tag.data) && tag.data.map((item, index) => (
+            <div key={`${tag.tagName}-${index}`} className="space-y-2">
               {Object.keys(item).map((label) => renderNestedItem(label, item[label]))}
-            </>
+            </div>
           ))}
-          {/* Objects */}
-          {(
-            !Array.isArray(tag.data) && (
-              (typeof tag.data !== 'string') || (typeof tag.data !== 'number'))
-            ) && (
-            <>
+          {!Array.isArray(tag.data) && tag.data && typeof tag.data === 'object' && (
+            <div className="space-y-2">
               {Object.keys(tag.data).map((label) => renderNestedItem(label, tag.data[label]))}
-            </>
+            </div>
           )}
         </div>
       </div>
     );
 
     const renderNormalTag = (tag) => (
-      <div key={tag.tagName} className='invoice__item'>
-        <div className='invoice__item-title'>
+      <div key={tag.tagName} className="flex flex-col gap-1 rounded-lg border border-border bg-background/40 p-4">
+        <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           {formatDetailsKey(tag.tagName)}
         </div>
-        <div className='invoice__item-value'>
-          {`${tag.data || '--'}`}
-        </div>
+        <div className="text-sm text-foreground break-words">{`${tag.data || '--'}`}</div>
       </div>
-    )
+    );
 
-    return tags.map((tag) => renderTag(tag));
-  }
+    return tags.map((tag) => (
+      typeof tag.data !== 'string' && typeof tag.data !== 'number'
+        ? renderNestedTag(tag)
+        : renderNormalTag(tag)
+    ));
+  };
 
-  renderInvoiceItem = (key, valuePropFormat) => {
-    const { decodedInvoice } = this.state;
-
+  const renderInvoiceItem = (key, valuePropFormat) => {
     let value = `${decodedInvoice[key]}`;
-    if (
-      valuePropFormat &&
-      valuePropFormat === TIMESTAMP_STRING_KEY
-    ) {
-      // TODO: this breaks
-      // value = `${formatTimestamp(decodedInvoice[key])}`;
+    if (valuePropFormat && valuePropFormat === TIMESTAMP_STRING_KEY) {
+      value = `${decodedInvoice[key]}`;
     }
 
     return (
-      <div
-        key={key}
-        className='invoice__item'
-      >
-        <div className='invoice__item-title'>
+      <div key={key} className="flex flex-col gap-1 rounded-lg border border-border bg-background/40 p-4">
+        <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           {formatDetailsKey(key)}
         </div>
-        <div className='invoice__item-value'>
-          {value}
-        </div>
+        <div className="text-sm text-foreground break-words">{value}</div>
       </div>
     );
-  }
+  };
 
-  renderLogo = () => (
-    <div className='logo'>
-      <div className='logo__title'>
-        {APP_NAME}
-      </div>
-      <div className='logo__subtitle'>
-        {APP_TAGLINE}
-        <span className="logo__subtitle-small">{APP_SUBTAGLINE}</span>
+  const invoiceDetails = !isInvoiceLoaded || isLNURL
+    ? null
+    : Object.keys(decodedInvoice).flatMap((key) => {
+      switch (key) {
+        case COMPLETE_KEY:
+          return [];
+        case TAGS_KEY:
+          return renderInvoiceInnerItems(key);
+        case TIMESTAMP_STRING_KEY:
+          return [renderInvoiceItem(key, TIMESTAMP_STRING_KEY)];
+        default:
+          return [renderInvoiceItem(key)];
+      }
+    });
+
+  const lnurlDetails = !isInvoiceLoaded || !isLNURL
+    ? null
+    : Object.keys(decodedInvoice).flatMap((key) => {
+      if (typeof decodedInvoice[key] === 'object') {
+        return [];
+      }
+
+      if (key === 'status') {
+        return [];
+      }
+
+      if (key === LNURL_TAG_KEY) {
+        const textLabel = decodedInvoice[key];
+        return [
+          <div key={`${key}-tag`} className="flex flex-col gap-1 rounded-lg border border-border bg-background/40 p-4">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {formatDetailsKey(key)}
+            </div>
+            <div className="text-sm text-foreground break-words">
+              <a className="text-primary underline-offset-4 hover:underline" href={decodedInvoice[key]}>
+                {textLabel}
+              </a>
+            </div>
+          </div>,
+        ];
+      }
+
+      if (key === CALLBACK_KEY) {
+        return [
+          <div key={`${key}-callback`} className="flex flex-col gap-1 rounded-lg border border-border bg-background/40 p-4">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {formatDetailsKey(key)}
+            </div>
+            <div className="text-sm text-foreground break-words">
+              <a className="text-primary underline-offset-4 hover:underline" href={decodedInvoice[key]}>
+                {decodedInvoice[key]}
+              </a>
+            </div>
+          </div>,
+        ];
+      }
+
+      if (key === LNURL_METADATA_KEY) {
+        const splitMetadata = JSON.parse(decodedInvoice[key]);
+
+        return splitMetadata.map((arrOfData, index) => {
+          if (arrOfData[0] === 'text/plain') {
+            return (
+              <div key={`${key}-description-${index}`} className="flex flex-col gap-1 rounded-lg border border-border bg-background/40 p-4">
+                <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Description
+                </div>
+                <div className="text-sm text-foreground break-words">{arrOfData[1]}</div>
+              </div>
+            );
+          }
+
+          if (arrOfData[0] === 'text/identifier') {
+            return (
+              <div key={`${key}-identifier-${index}`} className="flex flex-col gap-1 rounded-lg border border-border bg-background/40 p-4">
+                <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Lightning Address
+                </div>
+                <div className="text-sm text-foreground break-words">{arrOfData[1]}</div>
+              </div>
+            );
+          }
+
+          if (arrOfData[0] === 'image/png;base64') {
+            return (
+              <div key={`${key}-image-${index}`} className="flex flex-col gap-3 rounded-lg border border-border bg-background/40 p-4">
+                <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Image
+                </div>
+                <img
+                  alt="Image"
+                  className="max-w-[200px] rounded-md border border-border"
+                  src={`data:image/png;base64,${arrOfData[1]}`}
+                />
+              </div>
+            );
+          }
+
+          return null;
+        }).filter(Boolean);
+      }
+
+      return [
+        <div key={`${key}-default`} className="flex flex-col gap-1 rounded-lg border border-border bg-background/40 p-4">
+          <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {formatDetailsKey(key)}
+          </div>
+          <div className="text-sm text-foreground break-words">{decodedInvoice[key]}</div>
+        </div>,
+      ];
+    });
+
+  const hasError = Boolean(error);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-background via-background to-slate-950 text-foreground">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-10">
+        <header className="flex flex-col gap-3">
+          <div className="flex items-center gap-3">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/20 text-primary">
+              <Zap className="h-6 w-6" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-semibold tracking-tight">{APP_NAME}</h1>
+              <p className="text-sm text-muted-foreground">
+                {APP_TAGLINE}{' '}
+                <span className="text-xs uppercase tracking-[0.2em] text-muted-foreground/70">
+                  {APP_SUBTAGLINE}
+                </span>
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Button asChild variant="outline" className="gap-2">
+              <a href={APP_GITHUB} target="_blank" rel="noopener noreferrer">
+                <Github className="h-4 w-4" />
+                View on GitHub
+              </a>
+            </Button>
+            {isInvoiceLoaded && (
+              <Badge variant="secondary" className="self-center">Loaded</Badge>
+            )}
+            {isLNURL && (
+              <Badge variant="default" className="self-center">LNURL</Badge>
+            )}
+            {isLNAddress && (
+              <Badge variant="outline" className="self-center">Lightning Address</Badge>
+            )}
+          </div>
+        </header>
+
+        <Card className="bg-card/80">
+          <CardHeader>
+            <CardTitle>Decode an invoice</CardTitle>
+            <CardDescription>Paste a Lightning invoice, LNURL, or Lightning Address to inspect it.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex flex-col gap-3 md:flex-row md:items-center">
+              <div className="flex w-full items-center gap-3 rounded-md border border-border bg-background/60 px-3">
+                <Search className="h-4 w-4 text-muted-foreground" />
+                <Input
+                  value={text}
+                  onChange={handleChange}
+                  onKeyDown={handleKeyPress}
+                  placeholder={APP_INPUT_PLACEHOLDER}
+                  className="border-none bg-transparent px-0 focus-visible:ring-0 focus-visible:ring-offset-0"
+                  autoFocus
+                />
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button onClick={() => (isInvoiceLoaded ? clearInvoiceDetails() : getInvoiceDetails(text))}>
+                  {isInvoiceLoaded ? (
+                    <>
+                      <RotateCcw className="h-4 w-4" />
+                      Reset
+                    </>
+                  ) : (
+                    <>
+                      <Search className="h-4 w-4" />
+                      Decode
+                    </>
+                  )}
+                </Button>
+                {!isInvoiceLoaded && (
+                  <Dialog open={isQRCodeOpened} onOpenChange={setIsQRCodeOpened}>
+                    <DialogTrigger asChild>
+                      <Button variant="secondary">
+                        <QrCode className="h-4 w-4" />
+                        Scan QR
+                      </Button>
+                    </DialogTrigger>
+                    <DialogContent>
+                      <DialogHeader>
+                        <DialogTitle>Scan a Lightning QR</DialogTitle>
+                        <DialogDescription>Point your camera at a Lightning invoice QR code.</DialogDescription>
+                      </DialogHeader>
+                      <div className="rounded-lg border border-border bg-background/40 p-2">
+                        <QrReader
+                          delay={300}
+                          onError={handleError}
+                          onScan={handleScan}
+                          style={{ width: '100%' }}
+                        />
+                      </div>
+                    </DialogContent>
+                  </Dialog>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {isInvoiceLoaded && (
+          <Card className="bg-card/80">
+            <CardHeader className="flex flex-row items-center justify-between">
+              <div>
+                <CardTitle>{isLNURL ? 'LNURL Details' : 'Invoice Details'}</CardTitle>
+                <CardDescription>
+                  {isLNURL
+                    ? 'Fetched metadata and fields for the LNURL request.'
+                    : 'Parsed invoice fields and tags.'}
+                </CardDescription>
+              </div>
+            </CardHeader>
+            <CardContent className="grid gap-4 md:grid-cols-2">
+              {isLNURL ? lnurlDetails : invoiceDetails}
+            </CardContent>
+          </Card>
+        )}
+
+        {hasError && (
+          <Alert variant="destructive">
+            <AlertTitle>Unable to decode</AlertTitle>
+            <AlertDescription>{error.message || String(error)}</AlertDescription>
+          </Alert>
+        )}
       </div>
     </div>
   );
-
-  renderLNURLDetails = () => {
-    const { decodedInvoice, isInvoiceLoaded } = this.state;
-    const invoiceContainerClassnames = cx(
-      'invoice',
-      { 'invoice--opened': isInvoiceLoaded },
-    );
-
-    let requestContents = decodedInvoice;
-
-    return !isInvoiceLoaded ? null : (
-      <div className={invoiceContainerClassnames}>
-        {Object.keys(requestContents).map((key) => {
-          let text = decodedInvoice[key];
-          
-          if (typeof decodedInvoice[key] === 'object') {
-            return <></>;
-          }
-          
-          if (key === 'status') {
-            return <></>
-          }
-
-          if (key === LNURL_TAG_KEY) {
-            switch (key) {
-              case 'payRequest':
-                text = 'LNURL Pay (payRequest)'
-                break;
-              case 'withdrawRequest':
-                text = 'LNURL Withdraw (withdrawRequest)'
-                break;
-              default:
-                break;
-            }
-
-            return (
-              <div key={`${key}-${Math.random()}`} className='invoice__item'>
-                <div className='invoice__item-title'>
-                  {formatDetailsKey(key)}
-                </div>
-                <div className='invoice__item-value'>
-                  <a href={decodedInvoice[key]}>
-                    {text}
-                  </a>
-                </div>
-              </div>
-            )
-          }
-
-          if (key === CALLBACK_KEY) {
-            return (
-              <div key={`${key}-${Math.random()}`} className='invoice__item'>
-                <div className='invoice__item-title'>
-                  {formatDetailsKey(key)}
-                </div>
-                <div className='invoice__item-value'>
-                  <a href={decodedInvoice[key]}>
-                    {decodedInvoice[key]}
-                  </a>
-                </div>
-              </div>
-            )
-          }
-
-          if (key === LNURL_METADATA_KEY) {
-            const splitMetadata = JSON.parse(decodedInvoice[key]);
-
-            // eslint-disable-next-line array-callback-return
-            const toRender = splitMetadata.map((arrOfData) => {
-              if (arrOfData[0] === 'text/plain') {
-                return (
-                  <div key={`${key}-${Math.random()}`} className='invoice__item'>
-                    <div className='invoice__item-title'>
-                      Description
-                    </div>
-                    <div className='invoice__item-value'>
-                      {arrOfData[1]}
-                    </div>
-                  </div>
-                )
-              }
-
-              if (arrOfData[0] === 'text/identifier') {
-                return (
-                  <div key={`${key}-${Math.random()}`} className='invoice__item'>
-                    <div className='invoice__item-title'>
-                      Lightning Address
-                    </div>
-                    <div className='invoice__item-value'>
-                      {arrOfData[1]}
-                    </div>
-                  </div>
-                )
-              }
-
-              if (arrOfData[0] === 'image/png;base64') {
-                return (
-                  <div key={`${key}-${Math.random()}`} className='invoice__item'>
-                    <div className='invoice__item-title'>
-                      Image
-                    </div>
-                    <div className='invoice__item-value'>
-                      <img
-                        alt='Imager'
-                        style={{ maxWidth: '200px' }}
-                        src={`data:image/png;base64,${arrOfData[1]}`}
-                      />
-                    </div>
-                  </div>
-                );
-              }
-            });
-
-            return toRender;
-          }
-
-          return (
-            <div key={`${key}-${Math.random()}`} className='invoice__item'>
-              <div className='invoice__item-title'>
-                {formatDetailsKey(key)}
-              </div>
-              <div className='invoice__item-value'>
-                {decodedInvoice[key]}
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    );
-  }
-
-  renderSubmit = () => {
-    const { isInvoiceLoaded, text } = this.state;
-    const submitClassnames = cx(
-      'submit',
-      { 'submit__close': isInvoiceLoaded },
-    );
-
-    const onClick = () => {
-      if (isInvoiceLoaded) {
-        this.clearInvoiceDetails();
-      } else {
-        this.getInvoiceDetails(text);
-      }
-    }
-
-    return (
-      <div
-        onClick={onClick}
-        className={submitClassnames}
-      >
-        <img
-          alt='Submit'
-          src={isInvoiceLoaded ? closeImage : arrowImage}
-          className='submit__asset'
-        />
-      </div>
-    );
-  }
-
-  renderOptions = () => {
-    const { isInvoiceLoaded } = this.state;
-    const optionsClassnames = cx(
-      'options',
-      { 'options--hide': isInvoiceLoaded },
-    );
-
-    return (
-      <div className={optionsClassnames}>
-        <div className='options__wrapper'>
-          <a
-            href={APP_GITHUB}
-            className='options__github'
-            target='_blank'
-            rel='noopener noreferrer'
-          >
-            <img
-              className='options__github-icon'
-              src={githubImage}
-              alt='GitHub'
-            />
-          </a>
-        </div>
-      </div>
-    );
-  }
-
-  renderCamera = () => {
-    const { isQRCodeOpened, isInvoiceLoaded } = this.state;
-
-    const styleQRWrapper = cx({
-      'qrcode' : true,
-      'qrcode--opened': isQRCodeOpened,
-    });
-    const styleQRContainer = cx(
-      'qrcode__container',
-      { 'qrcode__container--opened': isQRCodeOpened },
-    );
-    const styleImgQR = cx(
-      'qrcode__img',
-      { 'qrcode__img--opened': isQRCodeOpened },
-    );
-
-    const qrReaderStyles = {
-      width: '100%',
-      border: '2pt solid #000000',
-    };
-
-    const srcImage = isQRCodeOpened ? closeImage : qrcodeImage;
-
-    const handleScan = (value) => {
-      if (Object.is(value, null)) return;
-
-      let text = value;
-      if (value.includes('lightning')) {
-        text = value.split('lightning:')[1];
-      }
-
-      this.getInvoiceDetails(text);
-      this.setState(() => ({
-        isQRCodeOpened: false,
-        text,
-      }));
-    }
-
-    const handleError = (error) => this.setState(() => ({
-      isInvoiceLoaded: false,
-      hasError: true,
-      error,
-      isQRCodeOpened: false
-    }));
-
-    return isInvoiceLoaded ? null : (
-      <div className={styleQRWrapper}>
-        {isQRCodeOpened && (
-          <div className='qrcode__modal' />
-        )}
-        <div className={styleQRContainer}>
-          <img
-            className={styleImgQR}
-            src={srcImage}
-            alt='QRCode'
-            onClick={this.handleQRCode}
-          />
-          {!isQRCodeOpened ? null : (
-            <QrReader
-              delay={300}
-              onError={handleError}
-              onScan={handleScan}
-              style={qrReaderStyles}
-            />
-          )}
-        </div>
-      </div>
-    );
-  }
-
-  render() {
-    const { isLNURL, isInvoiceLoaded, hasError } = this.state;
-
-    const appClasses = cx(
-      'app',
-      { 'app--opened': isInvoiceLoaded },
-    );
-    const appColumnClasses = cx(
-      'app__column',
-      {
-        'app__column--invoice-loaded': isInvoiceLoaded,
-        'app__column--error': hasError,
-      },
-    );
-    const appSubmitClasses = cx(
-      'app__submit',
-      { 'app__submit--invoice-loaded': isInvoiceLoaded },
-    );
-
-    return (
-      <div className={appClasses}>
-        {this.renderOptions()}
-        {this.renderLogo()}
-        <div className='app__row'>
-          {this.renderInput()}
-          <div className={appSubmitClasses}>
-            {this.renderSubmit()}
-            {this.renderCamera()}
-          </div>
-        </div>
-        <div className={appColumnClasses}>
-          {isLNURL ? this.renderLNURLDetails() : this.renderInvoiceDetails()}
-          {this.renderErrorDetails()}
-        </div>
-      </div>
-    );
-  }
 }

--- a/src/components/ui/alert.jsx
+++ b/src/components/ui/alert.jsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { cva } from 'class-variance-authority';
+
+import { cn } from '../../lib/utils';
+
+const alertVariants = cva(
+  'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4',
+  {
+    variants: {
+      variant: {
+        default: 'bg-background text-foreground',
+        destructive: 'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+const Alert = React.forwardRef(({ className, variant, ...props }, ref) => (
+  <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
+));
+Alert.displayName = 'Alert';
+
+const AlertTitle = React.forwardRef(({ className, ...props }, ref) => (
+  <h5 ref={ref} className={cn('mb-1 font-medium leading-none tracking-tight', className)} {...props} />
+));
+AlertTitle.displayName = 'AlertTitle';
+
+const AlertDescription = React.forwardRef(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('text-sm [&_p]:leading-relaxed', className)} {...props} />
+));
+AlertDescription.displayName = 'AlertDescription';
+
+export { Alert, AlertTitle, AlertDescription };

--- a/src/components/ui/badge.jsx
+++ b/src/components/ui/badge.jsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { cva } from 'class-variance-authority';
+
+import { cn } from '../../lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-md border border-transparent px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/80',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/80',
+        outline: 'border-border text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+function Badge({ className, variant, ...props }) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva } from 'class-variance-authority';
+
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+const Button = React.forwardRef(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+const Card = React.forwardRef(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('rounded-lg border border-border bg-card text-card-foreground shadow-sm', className)}
+    {...props}
+  />
+));
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+));
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef(({ className, ...props }, ref) => (
+  <h3 ref={ref} className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />
+));
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+));
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+));
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+));
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/src/components/ui/dialog.jsx
+++ b/src/components/ui/dialog.jsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+
+import { cn } from '../../lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({ className, ...props }) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+);
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogTitle = React.forwardRef(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+const Input = React.forwardRef(({ className, type, ...props }, ref) => (
+  <input
+    type={type}
+    className={cn(
+      'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+Input.displayName = 'Input';
+
+export { Input };

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,36 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 224 71% 4%;
+    --foreground: 210 40% 98%;
+    --card: 222 47% 11%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222 47% 11%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 45 93% 58%;
+    --primary-foreground: 222 47% 11%;
+    --secondary: 217 33% 17%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217 33% 17%;
+    --muted-foreground: 215 20% 65%;
+    --accent: 217 33% 17%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62% 51%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217 33% 17%;
+    --input: 217 33% 17%;
+    --ring: 45 93% 58%;
+    --radius: 0.75rem;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+  }
+
+  * {
+    @apply border-border;
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
 // Core Libs
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
+
+import './index.css';
 
 // Main Component
 import { App } from './app';
 
-// DOM Render
-ReactDOM.render(
-  <App />,
-  document.getElementById('root'),
-);
+const container = document.getElementById('root');
+const root = createRoot(container);
 
+root.render(<App />);

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,6 @@
+import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs) {
+  return twMerge(clsx(inputs));
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,49 @@
+module.exports = {
+  darkMode: ['class'],
+  content: ['./src/**/*.{js,jsx}', './public/index.html'],
+  theme: {
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+    },
+  },
+  plugins: [require('tailwindcss-animate')],
+};


### PR DESCRIPTION
### Motivation
- Replace the app's custom UI and styles with up-to-date shadcn-style UI primitives using Tailwind so the frontend is easier to maintain and reuse. 
- Move the codebase to modern React API and upgrade dependency versions to support the new UI primitives and tooling. 
- Preserve the exact existing functionality: invoice/LNURL parsing, QR scanning, URL updates and error handling. 
- Provide a Tailwind/PostCSS base and utility helpers compatible with shadcn component patterns. 

### Description
- Converted `src/app.js` from a class component to a functional component using React hooks and preserved all decode/QR behaviors while plugging in the new UI primitives. 
- Added shadcn-style components under `src/components/ui/` (`button`, `input`, `card`, `dialog`, `badge`, `alert`) and a `cn` helper at `src/lib/utils.js` for class merging. 
- Introduced Tailwind and PostCSS configuration and base stylesheet (`tailwind.config.js`, `postcss.config.js`, `src/index.css`) and switched the entry to the React 18 root API in `src/index.js`. 
- Updated `package.json` to reference updated/new dependencies (Radix, `clsx`, `class-variance-authority`, `lucide-react`, `tailwind-merge`, Tailwind tooling, and bumped `react`/`react-dom`) and changed scripts to use the newer toolchain. 

### Testing
- Attempted to install dependencies with `npm install` but it failed due to a `403 Forbidden` error from the npm registry, so the install step could not complete. 
- No automated tests or builds were successfully executed because dependency installation was blocked by the registry error. 
- A Git commit was created with the refactor changes. 
- Manual runtime verification was not possible in this environment due to the install error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966647ea4d0832aabdcee02dd76fe40)