### PR TITLE
README's production build documentation still claims output is written to

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm run build
 npm run preview
 ```
 
-Output is generated in the `/dist` directory.
+Output is generated in the `build/` directory.
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary
The README's production build documentation still claims output is written to `/dist`, but the Vite configuration was changed to emit to `build/` (commit `87f165d`) to align with Vercel, and the `build` folder is present at the project root. This leaves the setup instructions out of sync with the actual project configuration and is a straightforward, high-confidence docs-quality fix.

### Suggested fix
In `README.md`, replace the sentence `Output is generated in the `/dist` directory.` with `Output is generated in the `build/` directory.`

### Changes
README.md | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

### Verification commands
```
`grep -n "/dist" README.md` (should produce no output) and `npm run build && ls build` (to confirm the output directory exists)
```

### Risk assessment
low — it is a single-line documentation correction with no effect on application code, dependencies, or build behavior.

---
_Automated maintenance by `pi` + Fireworks/Kimi K2.6_