### PR TITLE
chore: add missing dev script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "start": "vite",
+    "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest",


### PR DESCRIPTION
## Summary

The README's Development section instructs users to run `npm run dev` to start the local development server, but `package.json` only defined a `start` script (`vite`). Running `npm run dev` currently fails with:

```
npm error Missing script: "dev"
```

## Changes

- Add `"dev": "vite"` to `package.json` scripts so the README instructions work as documented.
- Keep the existing `start` script unchanged for backward compatibility.

## Verification

```bash
npm run dev
# → Vite dev server starts at http://localhost:5173
```

## Risk assessment

low — single-line addition to package.json scripts with no effect on application code, dependencies, or build behavior.