### PR TITLE
test: add basic test for internet identifier validation

### DIFF
--- a/src/utils/internet-identifier.test.js
+++ b/src/utils/internet-identifier.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { validateInternetIdentifier } from './internet-identifier';
+
+describe('validateInternetIdentifier', () => {
+  it('returns true for valid email-like identifiers', () => {
+    expect(validateInternetIdentifier('user@example.com')).toBe(true);
+    expect(validateInternetIdentifier('name@domain.co.uk')).toBe(true);
+  });
+
+  it('returns false for invalid identifiers', () => {
+    expect(validateInternetIdentifier('notanemail')).toBe(false);
+    expect(validateInternetIdentifier('')).toBe(false);
+    expect(validateInternetIdentifier('user@')).toBe(false);
+    expect(validateInternetIdentifier('@domain.com')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a minimal test suite for `validateInternetIdentifier` so that `npm test` no longer exits with code 1 due to no test files being found.

## Before
`npm test` failed with:


## After
`npm test` passes with 2 tests covering the internet identifier validation utility.

## Test Plan
- [x] `npm test` passes locally