### PR TITLE
feature: Add LUD-01 fallback scheme support (lightning= param)

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -577,8 +577,12 @@ export class App extends PureComponent {
       if (Object.is(value, null)) return;
 
       let text = value;
-      if (value.includes('lightning')) {
+      if (value.includes('lightning:')) {
         text = value.split('lightning:')[1];
+      }
+
+      if (value.includes('lightning=')) {
+        text = value.split('lightning=')[1].split('&')[0];
       }
 
       this.getInvoiceDetails(text);

--- a/src/utils/invoices.js
+++ b/src/utils/invoices.js
@@ -37,18 +37,26 @@ export const parseInvoice = async (invoice) => {
     }
   }
 
-  // Check if Invoice has `lightning` or `lnurl` prefixes
+  // Check if Invoice has `lightning:` or `lnurl:` prefixes
   // (9 chars + the `:` or `=` chars) --> 10 characters total
   const hasLightningPrefix = lcInvoice.indexOf(`${LIGHTNING_SCHEME}:`) !== -1;
   if (hasLightningPrefix) {
-    // Remove the `lightning` prefix
+    // Remove the `lightning:` prefix
     requestCode = lcInvoice.slice(10, lcInvoice.length);
+  }
+
+  // Check for LUD-01 fallback scheme: `lightning=` parameter
+  const hasLightningParam = lcInvoice.indexOf(`${LIGHTNING_SCHEME}=`) !== -1;
+  if (hasLightningParam) {
+    // Remove everything before and including the `lightning=` parameter,
+    // and stop at the next `&` if there are more query parameters
+    requestCode = lcInvoice.split(`${LIGHTNING_SCHEME}=`)[1].split('&')[0];
   }
 
   // (5 chars + the `:` or `=` chars) --> 6 characters total
   const hasLNURLPrefix = lcInvoice.indexOf(`${LNURL_SCHEME}:`) !== -1;
   if (hasLNURLPrefix) {
-    // Remove the `lightning` prefix
+    // Remove the `lnurl:` prefix
     requestCode = lcInvoice.slice(6, lcInvoice.length);
   }
 


### PR DESCRIPTION
Adds support for URLs that embed a Lightning/LNURL invoice as a query parameter, per [LUD-01](https://github.com/lnurl/luds/blob/luds/01.md#fallback-scheme) spec.

**Example:**
`https://app.dfx.swiss/pl/?lightning=LNURL1DP68GURN8GHJ7CTSDYHXGENC9EEHW6TNWVHHVVF0D3H82UNVWQHHQMZLVFJK2ERYVG6RZCMYX33RVEPEV5YEJ9WT`

**Changes:**
- `src/utils/invoices.js`: Strip `lightning=` prefix and stop at next `&` query parameter
- `src/app.jsx`: Handle `lightning=` in QR scanner with same logic

**Also fixes a bug:** the old QR scanner code used `value.includes('lightning')` which matched both `lightning:` and `lightning=`, but then always called `split('lightning:')[1]` — which would return `undefined` for fallback URLs, causing the decoder to fail silently.

Co-authored-by: Danswar <danswarrior1@gmail.com>