### PR TITLE
fix: correct switch target in renderLNURLDetails for tag labels

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -387,7 +387,7 @@ export class App extends PureComponent {
           }
 
           if (key === LNURL_TAG_KEY) {
-            switch (key) {
+            switch (text) {
               case 'payRequest':
                 text = 'LNURL Pay (payRequest)'
                 break;


### PR DESCRIPTION
## Summary

The  statement in  was comparing  (always  since  is ) instead of  (the actual tag value from ). This meant the / label mappings were never applied.

## Changes

- Changed  to  so the tag label mapping works correctly for LNURL pay and withdraw requests.

## Test Plan

- [x] Code review confirms the fix is correct
- [x] The switch now evaluates against the actual LNURL tag value instead of the constant key name