### PR TITLE
fix: correct always-true condition in renderNestedTag

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -300,8 +300,7 @@ export class App extends PureComponent {
           ))}
           {/* Objects */}
           {(
-            !Array.isArray(tag.data) && (
-              (typeof tag.data !== 'string') || (typeof tag.data !== 'number'))
+            !Array.isArray(tag.data) && typeof tag.data !== 'string' && typeof tag.data !== 'number'
             ) && (
             <>
               {Object.keys(tag.data).map((label) => renderNestedItem(label, tag.data[label]))}


### PR DESCRIPTION
## Summary

The condition in the  method was a tautology:  is always true because a value cannot be both a string and a number simultaneously.

This caused the 'Objects' rendering branch to execute for strings, treating them as objects via , which produced individual character keys and duplicate rendering alongside the correct string branch.

## Changes

- Replaced the tautological OR with a proper AND chain: 
- The object branch now only renders when  is genuinely an object

## Test Plan

- [x] Code review confirms the condition is now correct
- [x] String data will no longer be rendered as objects