### PR TITLE
chore: remove dead timeExpireDate export from keys.js

### DIFF
--- a/src/constants/keys.js
+++ b/src/constants/keys.js
@@ -24,7 +24,6 @@ export const EXPIRY_HTLC = 'expiry_htlc';
 export const MIN_FINAL_CLTV_EXPIRY = 'min_final_cltv_expiry';
 export const TIME_EXPIRE_DATE_STRING = 'timeExpireDateString';
 export const TIME_EXPIRE_DATE = 'timeExpireDate';
-export const timeExpireDate = 'min_final_cltv_expiry';
 export const UNKNOWN_TAG_KEY = 'unknownTag';
 export const ROUTING_INFO_KEY = 'routing_info';
 export const TAG_CODE_KEY = 'tagCode';


### PR DESCRIPTION
## Summary

The  export in  was dead code with several issues:

1. **Unused**: It was never imported anywhere in the codebase
2. **Inconsistent naming**: It used camelCase instead of the SCREAMING_SNAKE_CASE convention used by all other exports
3. **Duplicate value**: It exported the same string as  (), creating confusion

## Changes

- Removed the unused  export

## Test Plan

- [x] Verified the export is not imported anywhere
- [x]  already provides the same value for any future needs