### PR TITLE
feat: support additional Bitcoin networks

### DIFF
--- a/src/lib/bolt11-networks.test.js
+++ b/src/lib/bolt11-networks.test.js
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const secp = vi.hoisted(() => {
+  const publicKeyHex = `02${'11'.repeat(32)}`
+
+  return {
+    publicKey: {
+      equals: (other) => other && other.toString('hex') === publicKeyHex,
+      toString: (encoding) => encoding === 'hex' ? publicKeyHex : publicKeyHex,
+    },
+    signature: {
+      toString: (encoding) => encoding === 'hex' ? '00'.repeat(64) : '00'.repeat(64),
+    },
+  }
+})
+
+vi.mock('secp256k1', () => ({
+  default: {
+    privateKeyVerify: vi.fn(() => true),
+    publicKeyCreate: vi.fn(() => secp.publicKey),
+    publicKeyVerify: vi.fn(() => true),
+    recover: vi.fn(() => secp.publicKey),
+    sign: vi.fn(() => ({
+      recovery: 0,
+      signature: secp.signature,
+    })),
+  },
+}))
+
+import { decode, encode, sign } from './bolt11'
+
+const PRIVATE_KEY = '0000000000000000000000000000000000000000000000000000000000000001'
+const PAYMENT_HASH = '0001020304050607080900010203040506070809000102030405060708090102'
+const FALLBACK_HASH = '00112233445566778899aabbccddeeff00112233'
+
+const makeInvoice = (coinType, tags = []) => {
+  const unsigned = encode({
+    coinType,
+    timestamp: 1672531200,
+    millisatoshis: '1000000',
+    tags: [
+      { tagName: 'payment_hash', data: PAYMENT_HASH },
+      { tagName: 'description', data: `${coinType} invoice` },
+      ...tags,
+    ],
+  }, false)
+
+  return sign(unsigned, PRIVATE_KEY).paymentRequest
+}
+
+describe('BOLT11 bitcoin networks', () => {
+  it('decodes signet invoices with testnet-compatible fallback addresses', () => {
+    const invoice = makeInvoice('signet', [
+      {
+        tagName: 'fallback_address',
+        data: {
+          code: 0,
+          addressHash: FALLBACK_HASH,
+        },
+      },
+    ])
+
+    const decoded = decode(invoice)
+    const fallbackAddress = decoded.tags.find(tag => tag.tagName === 'fallback_address')
+
+    expect(decoded.prefix).toMatch(/^lntbs/)
+    expect(decoded.coinType).toBe('signet')
+    expect(fallbackAddress.data.address).toMatch(/^tb1/)
+  })
+
+  it('decodes regtest invoices', () => {
+    const invoice = makeInvoice('regtest')
+    const decoded = decode(invoice)
+
+    expect(decoded.prefix).toMatch(/^lnbcrt/)
+    expect(decoded.coinType).toBe('regtest')
+  })
+
+  it('encodes testnet4 as a testnet-compatible BOLT11 invoice', () => {
+    const invoice = makeInvoice('testnet4')
+    const decoded = decode(invoice)
+
+    expect(decoded.prefix).toMatch(/^lntb/)
+    expect(decoded.coinType).toBe('testnet')
+  })
+})

--- a/src/lib/bolt11.js
+++ b/src/lib/bolt11.js
@@ -8,20 +8,28 @@ import * as bitcoinjsAddress from 'bitcoinjs-lib/src/address'
 import cloneDeep from 'lodash/cloneDeep'
 import coininfo from 'coininfo'
 
-const BITCOINJS_NETWORK_INFO = {
-  bitcoin: coininfo.bitcoin.main.toBitcoinJS(),
-  testnet: coininfo.bitcoin.test.toBitcoinJS(),
-  regtest: coininfo.bitcoin.regtest.toBitcoinJS(),
-  simnet: coininfo.bitcoin.regtest.toBitcoinJS(),
-  litecoin: coininfo.litecoin.main.toBitcoinJS(),
-  litecoin_testnet: coininfo.litecoin.test.toBitcoinJS()
+function createBitcoinJSNetwork (network, invoiceBech32, addressBech32) {
+  return {
+    ...network,
+    bech32: invoiceBech32,
+    addressBech32: addressBech32 || invoiceBech32
+  }
 }
-BITCOINJS_NETWORK_INFO.bitcoin.bech32 = 'bc'
-BITCOINJS_NETWORK_INFO.testnet.bech32 = 'tb'
-BITCOINJS_NETWORK_INFO.regtest.bech32 = 'bcrt'
-BITCOINJS_NETWORK_INFO.simnet.bech32 = 'sb'
-BITCOINJS_NETWORK_INFO.litecoin.bech32 = 'ltc'
-BITCOINJS_NETWORK_INFO.litecoin_testnet.bech32 = 'tltc'
+
+function getAddressBech32 (network) {
+  return network.addressBech32 || network.bech32
+}
+
+const BITCOINJS_NETWORK_INFO = {
+  bitcoin: createBitcoinJSNetwork(coininfo.bitcoin.main.toBitcoinJS(), 'bc'),
+  testnet: createBitcoinJSNetwork(coininfo.bitcoin.test.toBitcoinJS(), 'tb'),
+  testnet4: createBitcoinJSNetwork(coininfo.bitcoin.test.toBitcoinJS(), 'tb'),
+  signet: createBitcoinJSNetwork(coininfo.bitcoin.test.toBitcoinJS(), 'tbs', 'tb'),
+  regtest: createBitcoinJSNetwork(coininfo.bitcoin.regtest.toBitcoinJS(), 'bcrt'),
+  simnet: createBitcoinJSNetwork(coininfo.bitcoin.regtest.toBitcoinJS(), 'sb'),
+  litecoin: createBitcoinJSNetwork(coininfo.litecoin.main.toBitcoinJS(), 'ltc'),
+  litecoin_testnet: createBitcoinJSNetwork(coininfo.litecoin.test.toBitcoinJS(), 'tltc')
+}
 
 // defaults for encode; default timestamp is current time at call
 const DEFAULTNETWORKSTRING = 'main'
@@ -35,6 +43,7 @@ const VALIDWITNESSVERSIONS = [0]
 const BECH32CODES = {
   bc: 'bitcoin',
   tb: 'testnet',
+  tbs: 'signet',
   bcrt: 'regtest',
   sb: 'simnet',
   ltc: 'litecoin',
@@ -205,7 +214,7 @@ function fallbackAddressParser (words, network) {
       address = bitcoinjsAddress.toBase58Check(addressHash, network.scriptHash)
       break
     case 0:
-      address = bitcoinjsAddress.toBech32(addressHash, version, network.bech32)
+      address = bitcoinjsAddress.toBech32(addressHash, version, getAddressBech32(network))
       break
   }
 
@@ -562,7 +571,7 @@ function encode (inputData, addDefaults) {
       if (bech32addr && !(bech32addr.version in VALIDWITNESSVERSIONS)) {
         throw new Error('Fallback address witness version is unknown')
       }
-      if (bech32addr && bech32addr.prefix !== coinTypeObj.bech32) {
+      if (bech32addr && bech32addr.prefix !== getAddressBech32(coinTypeObj)) {
         throw new Error('Fallback address network type does not match payment request network type')
       }
       if (base58addr && base58addr.version !== coinTypeObj.pubKeyHash &&

--- a/src/utils/invoices.js
+++ b/src/utils/invoices.js
@@ -6,9 +6,8 @@ import { validateInternetIdentifier } from './internet-identifier';
 import * as LightningPayReq from '../lib/bolt11';
 
 const LIGHTNING_SCHEME = 'lightning';
-const BOLT11_SCHEME_MAINNET = 'lnbc';
-const BOLT11_SCHEME_TESTNET = 'lntb';
 const LNURL_SCHEME = 'lnurl';
+const BOLT11_SCHEMES = ['lnbcrt', 'lntbs', 'lnbc', 'lntb']; // regtest, signet, mainnet, testnet/testnet4
 const BOLT12_SCHEMES = ['lno1', 'lni1', 'lnr1']; // offer, invoice, invoice_request
 
 export const parseInvoice = async (invoice) => {
@@ -169,8 +168,9 @@ const handleLightningAddress = (internetIdentifier) => {
 };
 
 const handleBOLT11 = (invoice) => {
-  // Check if Invoice starts with `lnbc` prefix
-  if (!invoice.startsWith(BOLT11_SCHEME_MAINNET) && !invoice.startsWith(BOLT11_SCHEME_TESTNET)) {
+  // Check if Invoice starts with a known BOLT11 prefix
+  const isBOLT11 = BOLT11_SCHEMES.some(prefix => invoice.startsWith(prefix));
+  if (!isBOLT11) {
     return null;
   }
 

--- a/src/utils/invoices.test.js
+++ b/src/utils/invoices.test.js
@@ -3,10 +3,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // Mock the bolt11 module to avoid infinite loop bug
 vi.mock('../lib/bolt11', () => ({
   decode: vi.fn((invoice) => {
-    if (invoice.includes('lnbc')) {
+    if (invoice.startsWith('lnbcrt')) {
+      return {
+        complete: true,
+        prefix: 'lnbcrt',
+        coinType: 'regtest',
+        satoshis: 500,
+        millisatoshis: 500000,
+        timestamp: 1672531200,
+        tags: [
+          { tagName: 'payment_hash', data: '0001020304050607080900010203040506070809000102030405060708090102' },
+          { tagName: 'description', data: 'Regtest invoice' },
+        ],
+      };
+    }
+    if (invoice.startsWith('lnbc')) {
       return {
         complete: true,
         prefix: 'lnbc',
+        coinType: 'bitcoin',
         satoshis: 1000,
         millisatoshis: 1000000,
         timestamp: 1672531200,
@@ -17,10 +32,25 @@ vi.mock('../lib/bolt11', () => ({
         ],
       };
     }
-    if (invoice.includes('lntb')) {
+    if (invoice.startsWith('lntbs')) {
+      return {
+        complete: true,
+        prefix: 'lntbs',
+        coinType: 'signet',
+        satoshis: 500,
+        millisatoshis: 500000,
+        timestamp: 1672531200,
+        tags: [
+          { tagName: 'payment_hash', data: '0001020304050607080900010203040506070809000102030405060708090102' },
+          { tagName: 'description', data: 'Signet invoice' },
+        ],
+      };
+    }
+    if (invoice.startsWith('lntb')) {
       return {
         complete: true,
         prefix: 'lntb',
+        coinType: 'testnet',
         satoshis: 500,
         millisatoshis: 500000,
         timestamp: 1672531200,
@@ -139,6 +169,19 @@ describe('parseInvoice', () => {
       expect(result.data.satoshis).toBe(1000);
     });
 
+    it.each([
+      ['testnet/testnet4', 'lntb1pjtestnet', 'testnet'],
+      ['signet', 'lntbs1pjsignet', 'signet'],
+      ['regtest', 'lnbcrt1pjregtest', 'regtest'],
+    ])('strips lightning: prefix from BOLT11 %s invoice strings', async (_, invoice, coinType) => {
+      const { parseInvoice } = await import('./invoices');
+      const result = await parseInvoice(`lightning:${invoice}`);
+
+      expect(result.isLNURL).toBe(false);
+      expect(result.data).toBeDefined();
+      expect(result.data.coinType).toBe(coinType);
+    });
+
     it('does not strip lightning: when it appears inside an unrelated string', async () => {
       const { parseInvoice } = await import('./invoices');
       const result = await parseInvoice(`not-a-prefix-lightning:${VALID_BOLT11}`);
@@ -245,6 +288,19 @@ describe('parseInvoice', () => {
       expect(result.isLNURL).toBe(false);
       expect(result.data).toBeDefined();
       expect(result.data.satoshis).toBe(1000);
+    });
+
+    it.each([
+      ['testnet/testnet4', 'lntb1pjtestnet', 'testnet'],
+      ['signet', 'lntbs1pjsignet', 'signet'],
+      ['regtest', 'lnbcrt1pjregtest', 'regtest'],
+    ])('handles raw BOLT11 %s invoice strings', async (_, invoice, coinType) => {
+      const { parseInvoice } = await import('./invoices');
+      const result = await parseInvoice(invoice);
+
+      expect(result.isLNURL).toBe(false);
+      expect(result.data).toBeDefined();
+      expect(result.data.coinType).toBe(coinType);
     });
   });
 


### PR DESCRIPTION
- Add signet lntbs and regtest lnbcrt BOLT11 mappings
- Keep signet fallback addresses on the testnet tb address HRP
- Treat testnet4 as testnet-compatible lntb because BOLT11 has no distinct testnet4 HRP
- Allow the app wrapper to route the new prefixes and cover them in tests

I tested locally on a signet invoice. It works. The official site https://lightningdecoder.com determines the chain as "unknown".