### PR TITLE
chore: remove unused lodash dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "crypto-browserify": "^3.12.1",
         "date-fns": "^2.1.0",
         "events": "^3.3.0",
-        "lodash": "^4.17.15",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "safe-buffer": "^5.2.0",
@@ -2583,7 +2582,7 @@
     },
     "node_modules/coininfo": {
       "version": "5.1.0",
-      "resolved": "git+https://github.com/cryptocoinjs/coininfo.git#dc3e6cc59e593ee7dbeb7c993485706e72d32743",
+      "resolved": "git+ssh://git@github.com/cryptocoinjs/coininfo.git#dc3e6cc59e593ee7dbeb7c993485706e72d32743",
       "integrity": "sha512-k8LzTu37WW2Tb/kf1s+deX1t1Pk0RECQy4j1xDArsD01rQXocxwy3JFkraflnYwnKupXKrawkjU9pTr/n8I0sA==",
       "license": "MIT",
       "dependencies": {
@@ -4343,6 +4342,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "crypto-browserify": "^3.12.1",
     "date-fns": "^2.1.0",
     "events": "^3.3.0",
-    "lodash": "^4.17.15",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "safe-buffer": "^5.2.0",


### PR DESCRIPTION
## Summary

Removes `lodash` from production dependencies. It is not imported or used by any project code, yet it was included in the dependency list and shipped to the browser.

## Rationale

- Verified `lodash` is not imported anywhere in `src/` or `src/lib/`
- `lodash` is still available as a transitive dependency of `eslint` (devDependency), so linting continues to work
- Removing unused production dependencies reduces the installed package surface and avoids shipping unnecessary code

## Test Plan
- [x] `npm run build` passes
- [x] `npm test -- --run` passes (33/33 tests)
- [x] Verified no lodash imports remain in the codebase