### PR TITLE
fix(validation): tighten Lightning Address regex validation

### DIFF
--- a/src/utils/internet-identifier.js
+++ b/src/utils/internet-identifier.js
@@ -1,4 +1,4 @@
 export const validateInternetIdentifier = (internetIdentifier) => {
-    var re = /\S+@\S+\.\S+/;
+    var re = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)*\.[^\s@.]+$/;
     return re.test(internetIdentifier);
 }

--- a/src/utils/internet-identifier.test.js
+++ b/src/utils/internet-identifier.test.js
@@ -19,5 +19,7 @@ describe('validateInternetIdentifier', () => {
     expect(validateInternetIdentifier('user@.com')).toBe(false);
     expect(validateInternetIdentifier('LNURL1...')).toBe(false);
     expect(validateInternetIdentifier('lnbc1...')).toBe(false);
+    expect(validateInternetIdentifier('user@@domain.com')).toBe(false);
+    expect(validateInternetIdentifier('user@domain..com')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the Lightning Address validation regex to reject malformed identifiers like `user@@domain.com` and `user@domain..com`.

## Changes

- Tightens the regex in `validateInternetIdentifier` to use strict character classes
- Prevents multiple `@` symbols and consecutive dots in the domain portion
- Adds test cases for double `@` and double dot edge cases

## Before

The regex `/\S+@\S+\.\S+/` accepted invalid identifiers like `user@@domain.com` because `\S` matches any non-whitespace including `@` and `.`.

## After

The regex `/^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)*\.[^\s@.]+$/` explicitly:
- Rejects whitespace, `@`, and dots in the wrong places
- Requires a valid domain structure (label.label...)
- Anchors to start and end of string

## Testing

- All 52 existing tests pass
- New test cases cover double `@` and double dot edge cases