### PR TITLE
docs(readme): update test counts and remove non-existent scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A modern, developer-focused utility for parsing and understanding Lightning Netw
 - **Component Library** — Built with shadcn/ui components, fully customizable
 - **Storybook Documentation** — Interactive component documentation with live examples
 - **Type Safety** — Full TypeScript support across the codebase
-- **Comprehensive Testing** — 33 tests covering all invoice types and edge cases
+- **Comprehensive Testing** — 52 tests covering all invoice types and edge cases
 - **Modern Architecture** — Modular component design with clear separation of concerns
 
 ## 🚀 Quick Start
@@ -141,14 +141,9 @@ src/
 # Run all tests
 npm test
 
-# Run tests in watch mode
-npm run test:watch
-
-# Run tests with coverage
-npm run test:coverage
 ```
 
-Current coverage: **33 tests** across 5 test suites
+Current coverage: **52 tests** across 8 test suites
 
 - Invoice parsing (BOLT11, LNURL, BOLT12)
 - Lightning Address validation


### PR DESCRIPTION
## Summary

Syncs README documentation with the current project state.

## Changes

- Updates test count from **33 → 52** (reflects recent test additions)
- Updates test suite count from **5 → 8** (reflects new test files)
- Removes `npm run test:watch` and `npm run test:coverage` references
  - These scripts are not defined in `package.json`

## Verification

- `npm test` output: 8 test suites, 52 tests
- `package.json` scripts: only `test` (vitest) is defined