### PR TITLE
fix(keys): correct fee_proportional_millionths label

### DIFF
--- a/src/utils/keys.js
+++ b/src/utils/keys.js
@@ -136,7 +136,7 @@ export const formatDetailsKey = (key) => {
     case FEE_BASE_MSAT_KEY:
       return 'Fee Base (millisats)';
     case FEE_PROPORTIONAL_KEY:
-      return 'Tag Words';
+      return 'Fee Proportional (millionths)';
     case PUBKEY_KEY:
       return 'Public Key';
     case SHORT_CHANNEL_KEY:

--- a/src/utils/keys.test.js
+++ b/src/utils/keys.test.js
@@ -33,7 +33,7 @@ describe('formatDetailsKey', () => {
       { key: 'words', expected: 'Tag Words' },
       { key: 'cltv_expiry_delta', expected: 'CLTV Expiry Delta' },
       { key: 'fee_base_msat', expected: 'Fee Base (millisats)' },
-      { key: 'fee_proportional_millionths', expected: 'Tag Words' },
+      { key: 'fee_proportional_millionths', expected: 'Fee Proportional (millionths)' },
       { key: 'pubkey', expected: 'Public Key' },
       { key: 'short_channel_id', expected: 'Short Channel ID' },
       { key: 'callback', expected: 'Callback URL' },


### PR DESCRIPTION
## Problem

The `formatDetailsKey` function in `src/utils/keys.js` returned `'Tag Words'` for the `fee_proportional_millionths` key. This was a copy-paste error from the `TAG_WORDS_KEY` case above it.

## Impact

When displaying BOLT11 routing info, the "Fee Proportional (millionths)" field was incorrectly labeled as "Tag Words", which is confusing and incorrect.

## Fix

- Update the `FEE_PROPORTIONAL_KEY` case to return `'Fee Proportional (millionths)'`
- Update the corresponding test to assert the correct behavior

## Verification

All 52 tests pass.