### PR TITLE
refactor(keys): export humanizeKey and remove duplicate from invoice-details

### DIFF
--- a/src/components/invoice-details.tsx
+++ b/src/components/invoice-details.tsx
@@ -30,7 +30,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "./ui/sheet"
-import { formatDetailsKey } from "../utils/keys"
+import { formatDetailsKey, humanizeKey } from "../utils/keys"
 import { Check, Copy, ExternalLink, Info } from "lucide-react"
 
 export interface InvoiceDetailsProps {
@@ -176,16 +176,9 @@ const InvoiceDetails: React.FC<InvoiceDetailsProps> = ({
     }
   }
 
-  const humanizeNestedKey = (key: string) => key
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-    .replace(/[_-]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .replace(/\w\S*/g, word => word.charAt(0).toUpperCase() + word.slice(1))
-
   const getDisplayKey = (key: string) => {
     if (key.startsWith("payerData.")) {
-      return `Payer Data ${humanizeNestedKey(key.replace("payerData.", ""))}`
+      return `Payer Data ${humanizeKey(key.replace("payerData.", ""))}`
     }
 
     if (key === "amount") {
@@ -416,7 +409,7 @@ const InvoiceDetails: React.FC<InvoiceDetailsProps> = ({
         <div className="space-y-1">
           {Object.entries(value).map(([nestedKey, nestedValue]) => (
             <div key={nestedKey} className="flex items-center justify-between gap-3 text-xs">
-              <span className="text-muted-foreground">{humanizeNestedKey(nestedKey)}</span>
+              <span className="text-muted-foreground">{humanizeKey(nestedKey)}</span>
               <span className="text-right">{renderPayerDataFieldValue(nestedValue)}</span>
             </div>
           ))}

--- a/src/utils/keys.js
+++ b/src/utils/keys.js
@@ -68,7 +68,7 @@ import {
   BOLT12_NODE_ID_KEY,
 } from '../constants/keys';
 
-const humanizeKey = (key) => key
+export const humanizeKey = (key) => key
   .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
   .replace(/[_-]+/g, ' ')
   .replace(/\s+/g, ' ')


### PR DESCRIPTION
## Summary

Remove duplicate key formatting logic by exporting `humanizeKey` from the shared utility module and using it in `invoice-details.tsx`.

## Problem

The `humanizeNestedKey` function in `src/components/invoice-details.tsx` was identical to the private `humanizeKey` function in `src/utils/keys.js`. Both functions performed the same camelCase/snake_case to human-readable title conversion.

## Changes

- Export `humanizeKey` from `src/utils/keys.js`
- Import `humanizeKey` in `src/components/invoice-details.tsx`
- Remove the local `humanizeNestedKey` duplicate

## Benefits

- Single source of truth for key humanization
- Prevents drift if formatting rules need to change
- ~7 lines of code removed

## Verification

- All 52 tests pass
- Production build succeeds
- No runtime behavior changes