### PR TITLE
fix: correct label for fee_proportional_millionths key

### DIFF
--- a/src/utils/keys.js
+++ b/src/utils/keys.js
@@ -136,7 +136,7 @@ export const formatDetailsKey = (key) => {
     case FEE_BASE_MSAT_KEY:
       return 'Fee Base (millisats)';
     case FEE_PROPORTIONAL_KEY:
-      return 'Tag Words';
+      return 'Fee Proportional (parts per million)';
     case PUBKEY_KEY:
       return 'Public Key';
     case SHORT_CHANNEL_KEY:

--- a/src/utils/keys.test.js
+++ b/src/utils/keys.test.js
@@ -33,7 +33,7 @@ describe('formatDetailsKey', () => {
       { key: 'words', expected: 'Tag Words' },
       { key: 'cltv_expiry_delta', expected: 'CLTV Expiry Delta' },
       { key: 'fee_base_msat', expected: 'Fee Base (millisats)' },
-      { key: 'fee_proportional_millionths', expected: 'Tag Words' },
+      { key: 'fee_proportional_millionths', expected: 'Fee Proportional (parts per million)' },
       { key: 'pubkey', expected: 'Public Key' },
       { key: 'short_channel_id', expected: 'Short Channel ID' },
       { key: 'callback', expected: 'Callback URL' },


### PR DESCRIPTION
## Summary
Fixes a copy-paste bug where the `FEE_PROPORTIONAL_KEY` case in `formatDetailsKey` was returning the wrong label. It was returning `'Tag Words'` (the same as `TAG_WORDS_KEY`) instead of a fee-related label.

## Changes
- Updated `src/utils/keys.js`: `FEE_PROPORTIONAL_KEY` now returns `'Fee Proportional (parts per million)'`
- Updated `src/utils/keys.test.js`: corrected the expected test value

## Testing
- All 52 tests pass