### PR TITLE
chore(deps): resolve lodash and qs audit advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -362,14 +362,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.1.tgz",
-      "integrity": "sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2575,9 +2572,9 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-actions": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.6.14.tgz",
-      "integrity": "sha512-mDQxylxGGCQSK7tJPkD144J8jWh9IU9ziJMHfB84PKpI/V5ZgqMDnpr2bssTrUaGDqU5e1/z8KcRF+Melhs9pQ==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.6.18.tgz",
+      "integrity": "sha512-GcYhtE91GjIQTuZlwpTJ8jfMp6NC79nkpe1DGe0eetTpyQqLq1WUt+ACkk0Z5lqq2u8HBc09zCCGw+D8iCLpYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2592,13 +2589,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.6.14"
+        "storybook": "^8.6.18"
       }
     },
     "node_modules/@storybook/addon-backgrounds": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-8.6.14.tgz",
-      "integrity": "sha512-l9xS8qWe5n4tvMwth09QxH2PmJbCctEvBAc1tjjRasAfrd69f7/uFK4WhwJAstzBTNgTc8VXI4w8ZR97i1sFbg==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-8.6.18.tgz",
+      "integrity": "sha512-froND3WwvSCYzjEBO8QODStaWNL+aGXqxBEbrMnGYejDFST4qEFkvM2IYWMnLBkRgrgJ0yIqTeDQoyH9b9/8uQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2611,13 +2608,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.6.14"
+        "storybook": "^8.6.18"
       }
     },
     "node_modules/@storybook/addon-controls": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-8.6.14.tgz",
-      "integrity": "sha512-IiQpkNJdiRyA4Mq9mzjZlvQugL/aE7hNgVxBBGPiIZG6wb6Ht9hNnBYpap5ZXXFKV9p2qVI0FZK445ONmAa+Cw==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-8.6.18.tgz",
+      "integrity": "sha512-K09dHDCfGW3cudsfuyfu0Yi49aZ2h7VYK4IXDGo1sfmtzVh4xd3HrZQQMVUeKLcfDP/NnJowT+fLVwg04CLrxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2630,20 +2627,20 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.6.14"
+        "storybook": "^8.6.18"
       }
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-8.6.14.tgz",
-      "integrity": "sha512-Obpd0OhAF99JyU5pp5ci17YmpcQtMNgqW2pTXV8jAiiipWpwO++hNDeQmLmlSXB399XjtRDOcDVkoc7rc6JzdQ==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-8.6.18.tgz",
+      "integrity": "sha512-55ADer0yNmmeR928Y3UAv3r4i7bJSd9LwywsQ+lRol/FNe0ZcwLEz31xL+jVsqQFNnDh/imsDIp8aYapGMtfEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/blocks": "8.6.14",
-        "@storybook/csf-plugin": "8.6.14",
-        "@storybook/react-dom-shim": "8.6.14",
+        "@storybook/blocks": "8.6.18",
+        "@storybook/csf-plugin": "8.6.18",
+        "@storybook/react-dom-shim": "8.6.18",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -2653,25 +2650,25 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.6.14"
+        "storybook": "^8.6.18"
       }
     },
     "node_modules/@storybook/addon-essentials": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-8.6.14.tgz",
-      "integrity": "sha512-5ZZSHNaW9mXMOFkoPyc3QkoNGdJHETZydI62/OASR0lmPlJ1065TNigEo5dJddmZNn0/3bkE8eKMAzLnO5eIdA==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-8.6.18.tgz",
+      "integrity": "sha512-MmH7gFb8pyfRoAth0w2RW8j7mBaEJbEWGP3juIoH03ZqTGmbMUbJXElCuRgxQhve7pyz39zLsgtE78D7G+76ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/addon-actions": "8.6.14",
-        "@storybook/addon-backgrounds": "8.6.14",
-        "@storybook/addon-controls": "8.6.14",
-        "@storybook/addon-docs": "8.6.14",
-        "@storybook/addon-highlight": "8.6.14",
-        "@storybook/addon-measure": "8.6.14",
-        "@storybook/addon-outline": "8.6.14",
-        "@storybook/addon-toolbars": "8.6.14",
-        "@storybook/addon-viewport": "8.6.14",
+        "@storybook/addon-actions": "8.6.18",
+        "@storybook/addon-backgrounds": "8.6.18",
+        "@storybook/addon-controls": "8.6.18",
+        "@storybook/addon-docs": "8.6.18",
+        "@storybook/addon-highlight": "8.6.18",
+        "@storybook/addon-measure": "8.6.18",
+        "@storybook/addon-outline": "8.6.18",
+        "@storybook/addon-toolbars": "8.6.18",
+        "@storybook/addon-viewport": "8.6.18",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -2679,13 +2676,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.6.14"
+        "storybook": "^8.6.18"
       }
     },
     "node_modules/@storybook/addon-highlight": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.6.14.tgz",
-      "integrity": "sha512-4H19OJlapkofiE9tM6K/vsepf4ir9jMm9T+zw5L85blJZxhKZIbJ6FO0TCG9PDc4iPt3L6+aq5B0X29s9zicNQ==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.6.18.tgz",
+      "integrity": "sha512-wTFJ1DPM0C8gK6nGTJxH75byayQj7BPAz02fME4AOmT6clrBpVl1zSTFTkXaSr+k4xOfeMR/xNUfVskaXz6T9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2696,7 +2693,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.6.14"
+        "storybook": "^8.6.18"
       }
     },
     "node_modules/@storybook/addon-interactions": {
@@ -2853,9 +2850,9 @@
       }
     },
     "node_modules/@storybook/addon-measure": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-8.6.14.tgz",
-      "integrity": "sha512-1Tlyb72NX8aAqm6I6OICsUuGOP6hgnXcuFlXucyhKomPa6j3Eu2vKu561t/f0oGtAK2nO93Z70kVaEh5X+vaGw==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-8.6.18.tgz",
+      "integrity": "sha512-fMEOJXgPrTm6qHlWoRM+WTLE7Mr1QBIf2ei+pujBQFcWkD6Gjc2pV8zKzvh93d+EA13wD8AmwOq1DEw9J+XH+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2867,13 +2864,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.6.14"
+        "storybook": "^8.6.18"
       }
     },
     "node_modules/@storybook/addon-outline": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-outline/-/addon-outline-8.6.14.tgz",
-      "integrity": "sha512-CW857JvN6OxGWElqjlzJO2S69DHf+xO3WsEfT5mT3ZtIjmsvRDukdWfDU9bIYUFyA2lFvYjncBGjbK+I91XR7w==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-outline/-/addon-outline-8.6.18.tgz",
+      "integrity": "sha512-TErFqfCtlV2xt9B6/kskROt69TPjr6AXdHpMselaRrN1X4WEjcMk9GT9PcNP7FXqL88/VYqUb3uNMiAmpDmS/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2885,13 +2882,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.6.14"
+        "storybook": "^8.6.18"
       }
     },
     "node_modules/@storybook/addon-toolbars": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-8.6.14.tgz",
-      "integrity": "sha512-W/wEXT8h3VyZTVfWK/84BAcjAxTdtRiAkT2KAN0nbSHxxB5KEM1MjKpKu2upyzzMa3EywITqbfy4dP6lpkVTwQ==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-8.6.18.tgz",
+      "integrity": "sha512-x037KXCEcNfPISGX485DtiP+8Bw/cOT45plcQa8eiAQVrVcUwYaDoLubE9YV5b5CsSAjX8sDviGTme6ALfq7+w==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2899,13 +2896,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.6.14"
+        "storybook": "^8.6.18"
       }
     },
     "node_modules/@storybook/addon-viewport": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-8.6.14.tgz",
-      "integrity": "sha512-gNzVQbMqRC+/4uQTPI2ZrWuRHGquTMZpdgB9DrD88VTEjNudP+J6r8myLfr2VvGksBbUMHkGHMXHuIhrBEnXYA==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-8.6.18.tgz",
+      "integrity": "sha512-z9sDJSkuWQb4BP+Z1+H+y/Q0rFbPSDcw+OBBEhMfRcJPPXavdC2pNQ0GdQNVw+tDwhAXj+U7jehKnMDKaP7TyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2916,13 +2913,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.6.14"
+        "storybook": "^8.6.18"
       }
     },
     "node_modules/@storybook/blocks": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-8.6.14.tgz",
-      "integrity": "sha512-rBMHAfA39AGHgkrDze4RmsnQTMw1ND5fGWobr9pDcJdnDKWQWNRD7Nrlxj0gFlN3n4D9lEZhWGdFrCbku7FVAQ==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-8.6.18.tgz",
+      "integrity": "sha512-esZv4msPQ9LxgTb8YUIZhhxVMuI6BPi5bkXtk8c7w7sWuAsqsCe/RnVInn7ooUry2gjnD4hd9+8Eqj0b8oTVoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2936,7 +2933,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^8.6.14"
+        "storybook": "^8.6.18"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -2965,23 +2962,6 @@
       "peerDependencies": {
         "storybook": "^8.6.18",
         "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/@storybook/csf-plugin": {
-      "version": "8.6.18",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.6.18.tgz",
-      "integrity": "sha512-x1ioz/L0CwaelCkHci3P31YtvwayN3FBftvwQOPbvRh9qeb4Cpz5IdVDmyvSxxYwXN66uAORNoqgjTi7B4/y5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unplugin": "^1.3.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.18"
       }
     },
     "node_modules/@storybook/components": {
@@ -3044,9 +3024,9 @@
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.6.14.tgz",
-      "integrity": "sha512-dErtc9teAuN+eelN8FojzFE635xlq9cNGGGEu0WEmMUQ4iJ8pingvBO1N8X3scz4Ry7KnxX++NNf3J3gpxS8qQ==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.6.18.tgz",
+      "integrity": "sha512-x1ioz/L0CwaelCkHci3P31YtvwayN3FBftvwQOPbvRh9qeb4Cpz5IdVDmyvSxxYwXN66uAORNoqgjTi7B4/y5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3057,7 +3037,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.6.14"
+        "storybook": "^8.6.18"
       }
     },
     "node_modules/@storybook/global": {
@@ -3203,9 +3183,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.6.14.tgz",
-      "integrity": "sha512-0hixr3dOy3f3M+HBofp3jtMQMS+sqzjKNgl7Arfuj3fvjmyXOks/yGjDImySR4imPtEllvPZfhiQNlejheaInw==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.6.18.tgz",
+      "integrity": "sha512-N4xULcAWZQTUv4jy1/d346Tyb4gufuC3UaLCuU/iVSZ1brYF4OW3ANr+096btbMxY8pR/65lmtoqr5CTGwnBvA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3215,7 +3195,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.6.14"
+        "storybook": "^8.6.18"
       }
     },
     "node_modules/@storybook/react-vite": {
@@ -3253,22 +3233,6 @@
         "@storybook/test": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@storybook/react/node_modules/@storybook/react-dom-shim": {
-      "version": "8.6.18",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.6.18.tgz",
-      "integrity": "sha512-N4xULcAWZQTUv4jy1/d346Tyb4gufuC3UaLCuU/iVSZ1brYF4OW3ANr+096btbMxY8pR/65lmtoqr5CTGwnBvA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.6.18"
       }
     },
     "node_modules/@storybook/test": {
@@ -4692,12 +4656,12 @@
       }
     },
     "node_modules/browserify-sign": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz",
-      "integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
+      "integrity": "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==",
       "license": "ISC",
       "dependencies": {
-        "bn.js": "^5.2.2",
+        "bn.js": "^5.2.3",
         "browserify-rsa": "^4.1.1",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
@@ -6635,9 +6599,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/loupe": {
@@ -7342,9 +7306,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -7606,13 +7570,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",


### PR DESCRIPTION
## Summary
Runs `npm audit fix` to resolve two production-affecting dependency vulnerabilities:

- **lodash** — high severity prototype pollution via array path bypass in `_.unset` and `_.omit` ([GHSA-f23m-r3pf-42rh](https://github.com/advisories/GHSA-f23m-r3pf-42rh))
- **qs** — moderate severity remotely triggerable DoS via `qs.stringify` crash on null/undefined entries in comma-format arrays ([GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26))

## Changes
- Updates `package-lock.json` to pull patched versions of affected transitive dependencies
- No application code changes

## Remaining Advisories
13 additional low/moderate severity advisories remain in transitive dev dependencies (`elliptic` via `crypto-browserify` → `vite-plugin-node-polyfills`, and `uuid` via `@storybook/addon-essentials`). Resolving these requires breaking changes to major packages and is out of scope for this focused fix.

## Testing
- `npm audit` now shows 13 remaining (down from 16)
- `npm test` passes (52 tests)
- `npm run build` completes successfully