### PR TITLE
docs(readme): correct build output directory and update architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ src/
 │   ├── error-display.tsx      # Error/warning callout component
 │   └── theme-provider.tsx     # Theme context provider
 ├── lib/
+│   ├── bolt11.js              # BOLT11 invoice encode/decode
+│   ├── bolt11-networks.test.js # BOLT11 network tests
 │   └── utils.ts               # Utility functions (cn helper)
 ├── utils/
 │   ├── app-routes.ts          # Reserved route and invoice URL helpers
@@ -167,7 +169,7 @@ npm run build
 npm run preview
 ```
 
-Output is generated in the `dist/` directory.
+Output is generated in the `build/` directory.
 
 ## 🎨 Theming
 


### PR DESCRIPTION
## Summary
Fixes two documentation issues in the README that don't match the current codebase.

## Changes
- **Build output directory**: corrected from `dist/` to `build/` (matches `vite.config.js` which sets `outDir: 'build'`)
- **Architecture section**: added `src/lib/bolt11.js` and `src/lib/bolt11-networks.test.js` to the component structure tree

## Verification
- Confirmed `vite.config.js` has `build: { outDir: 'build' }`
- No application code changes