### PR TITLE
chore(deps): remove dead code from constants

### DIFF
--- a/src/constants/app.js
+++ b/src/constants/app.js
@@ -1,6 +1,0 @@
-// App-Wide Constants
-export const APP_NAME = 'Lightning Decoder';
-export const APP_TAGLINE = 'Decode Lightning Network Requests';
-export const APP_SUBTAGLINE = 'Lightning Address, LNURL, BOLT11, and BOLT12'
-export const APP_INPUT_PLACEHOLDER = 'Enter Invoice';
-export const APP_GITHUB = 'https://github.com/andrerfneves/lightning-decoder';

--- a/src/constants/keys.js
+++ b/src/constants/keys.js
@@ -24,7 +24,6 @@ export const EXPIRY_HTLC = 'expiry_htlc';
 export const MIN_FINAL_CLTV_EXPIRY = 'min_final_cltv_expiry';
 export const TIME_EXPIRE_DATE_STRING = 'timeExpireDateString';
 export const TIME_EXPIRE_DATE = 'timeExpireDate';
-export const timeExpireDate = 'min_final_cltv_expiry';
 export const UNKNOWN_TAG_KEY = 'unknownTag';
 export const ROUTING_INFO_KEY = 'routing_info';
 export const TAG_CODE_KEY = 'tagCode';


### PR DESCRIPTION
## Summary
Removes unused code that is not imported anywhere in the codebase.

## Changes
- **Delete `src/constants/app.js`**: never imported by any source file; constants (APP_NAME, APP_TAGLINE, etc.) are unused
- **Remove buggy `timeExpireDate` export from `src/constants/keys.js`**: lowercase export with incorrect value (`'min_final_cltv_expiry'` instead of `'timeExpireDate'`) and not imported anywhere

## Verification
- Grepped entire `src/` tree: no imports of `../constants/app` or lowercase `timeExpireDate`
- All 52 tests pass
- No application behavior changes