### PR TITLE
chore(deps): replace lodash cloneDeep with structuredClone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "crypto-browserify": "^3.12.1",
         "events": "^3.3.0",
         "framer-motion": "^12.40.0",
-        "lodash": "^4.17.15",
         "lucide-react": "^1.17.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -6602,6 +6601,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/loupe": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "crypto-browserify": "^3.12.1",
     "events": "^3.3.0",
     "framer-motion": "^12.40.0",
-    "lodash": "^4.17.15",
     "lucide-react": "^1.17.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/lib/bolt11.js
+++ b/src/lib/bolt11.js
@@ -5,7 +5,6 @@ import secp256k1 from 'secp256k1'
 import { Buffer } from 'buffer'
 import BN from 'bn.js'
 import * as bitcoinjsAddress from 'bitcoinjs-lib/src/address'
-import cloneDeep from 'lodash/cloneDeep'
 import coininfo from 'coininfo'
 
 function createBitcoinJSNetwork (network, invoiceBech32, addressBech32) {
@@ -383,7 +382,7 @@ function hrpToMillisat (hrpString, outputString) {
 }
 
 function sign (inputPayReqObj, inputPrivateKey) {
-  let payReqObj = cloneDeep(inputPayReqObj)
+  let payReqObj = structuredClone(inputPayReqObj)
   let privateKey = hexToBuffer(inputPrivateKey)
   if (payReqObj.complete && payReqObj.paymentRequest) return payReqObj
 
@@ -458,7 +457,7 @@ function sign (inputPayReqObj, inputPrivateKey) {
 */
 function encode (inputData, addDefaults) {
   // we don't want to affect the data being passed in, so we copy the object
-  let data = cloneDeep(inputData)
+  let data = structuredClone(inputData)
 
   // by default we will add default values to description, expire time, and min cltv
   if (addDefaults === undefined) addDefaults = true


### PR DESCRIPTION
## Summary
Replaces the single lodash usage (`cloneDeep`) with the native `structuredClone` API, allowing lodash to be removed from dependencies.

## Changes
- Replace `import cloneDeep from 'lodash/cloneDeep'` in `src/lib/bolt11.js` with `structuredClone`
- Remove `lodash` from `package.json` dependencies
- Update `package-lock.json`

## Rationale
`structuredClone` is supported in all modern browsers (per the project's `browserslist` config) and in jsdom v29.1.1 used for testing. The BOLT11 data objects being cloned are plain JSON-serializable objects, which `structuredClone` handles correctly.

## Verification
- All 52 tests pass
- `npm run build` completes successfully
- Bundle size reduced by ~36 KB (1,778 KB vs 1,814 KB before)
- No application behavior changes