### PR TITLE
fix(invoices): preserve Lightning Address error messages instead of generic catch-all

### DIFF
--- a/src/utils/invoices.js
+++ b/src/utils/invoices.js
@@ -159,10 +159,10 @@ const handleLightningAddress = (internetIdentifier) => {
         username,
       },
     }
-  }).catch(_ => {
+  }).catch(error => {
     return {
       success: false,
-      message: 'This identifier does not support Lightning Address yet.',
+      message: error.message || 'Could not resolve Lightning Address.',
     };
   });
 };

--- a/src/utils/invoices.test.js
+++ b/src/utils/invoices.test.js
@@ -97,7 +97,7 @@ describe('parseInvoice', () => {
 
       expect(result).toEqual({
         data: null,
-        error: 'This identifier does not support Lightning Address yet.',
+        error: 'Not found',
         isLNURL: false,
         isLNAddress: true,
       });


### PR DESCRIPTION
## Summary
The `handleLightningAddress` catch block was swallowing all errors and returning the same misleading message regardless of the actual failure cause.

## Problem
- Network errors, CORS failures, JSON parse errors, and HTTP errors all produced: "This identifier does not support Lightning Address yet."
- This was misleading because the error could be a temporary network issue, not a missing Lightning Address implementation.

## Changes
- Preserve the original `error.message` in the catch block
- Fall back to "Could not resolve Lightning Address." when the message is empty
- Update test expectation to match actual error propagation

## Verification
- All 52 tests pass
- `npm run build` completes successfully
- No application behavior changes beyond more accurate error messages