### PR TITLE
fix(bolt11): remove misleading extra argument from convert call in wordsToBuffer

### DIFF
--- a/src/lib/bolt11.js
+++ b/src/lib/bolt11.js
@@ -166,7 +166,7 @@ function convert (data, inBits, outBits) {
 }
 
 function wordsToBuffer (words, trim) {
-  let buffer = Buffer.from(convert(words, 5, 8, true))
+  let buffer = Buffer.from(convert(words, 5, 8))
   if (trim && words.length * 5 % 8 !== 0) {
     buffer = buffer.slice(0, -1)
   }


### PR DESCRIPTION
## Summary
The `wordsToBuffer` function passed a fourth argument (`true`) to `convert()`, but `convert()` only accepts three parameters.

## Problem
- `convert(words, 5, 8, true)` looked like it was toggling a padding behavior, but `convert()` does not have a fourth parameter
- The `true` was silently ignored, making the code misleading
- `convert()` is called with three arguments everywhere else in the file

## Changes
- Remove the extraneous `true` from `convert(words, 5, 8, true)`
- `convert()\'s padding is always added; `wordsToBuffer` already handles trimming via its own `trim` parameter

## Verification
- All 52 tests pass
- `npm run build` completes successfully
- No behavior change