### PR TITLE
fix(bolt11): replace confusing in operator with explicit range check for recovery flag

### DIFF
--- a/src/lib/bolt11.js
+++ b/src/lib/bolt11.js
@@ -751,7 +751,7 @@ function decode (paymentRequest, network) {
   let recoveryFlag = sigBuffer.slice(-1)[0]
   sigBuffer = sigBuffer.slice(0, -1)
 
-  if (!(recoveryFlag in [0, 1, 2, 3]) || sigBuffer.length !== 64) {
+  if (recoveryFlag < 0 || recoveryFlag > 3 || sigBuffer.length !== 64) {
     throw new Error('Signature is missing or incorrect')
   }
 


### PR DESCRIPTION
## Summary
The `decode` function used `recoveryFlag in [0, 1, 2, 3]` to validate the recovery flag. The `in` operator checks property names (array indices), not values.

## Problem
- `in` checks if a value is a property of the object, not if it is a value in the array
- For arrays it happens to work because the indices are `0, 1, 2, 3`, but this is coincidental and misleading
- If the array values ever changed, the check would still behave the same (checking indices), which is a footgun

## Changes
- Replace `!(recoveryFlag in [0, 1, 2, 3])` with `recoveryFlag < 0 || recoveryFlag > 3`
- The range check is clearer, more explicit, and does not rely on the coincidence that array indices match the valid recovery flag values

## Verification
- All 52 tests pass
- `npm run build` completes successfully
- No behavior change — the same values are rejected and accepted