### PR TITLE
fix(docker): correct build output path in Dockerfile (dist -> build)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN npm run build
 FROM nginx:alpine
 
 # Copy built assets from builder
-COPY --from=builder /app/dist /usr/share/nginx/html
+COPY --from=builder /app/build /usr/share/nginx/html
 
 # Copy nginx configuration
 COPY nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Summary
The Dockerfile copies build artifacts from `/app/dist`, but Vite is configured with `build.outDir: "build"` in `vite.config.js`. This means Docker builds would fail because the source path does not exist.

## Problem
- `COPY --from=builder /app/dist /usr/share/nginx/html` references a directory that does not exist
- Vite outputs to `build/`, not `dist/`
- Running `docker build` would fail with a "file not found" error

## Changes
- Changed `COPY --from=builder /app/dist /usr/share/nginx/html` to `COPY --from=builder /app/build /usr/share/nginx/html`

## Verification
- `npm run build` outputs to `build/` (confirmed)
- No application behavior changes
- Docker build will now succeed