### PR TITLE
docs(deployment): correct build output directory references (dist -> build)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -58,16 +58,16 @@ Since Lightning Decoder is a static site built with Vite, it can be deployed to 
 npm run build
 ```
 
-This creates a `dist/` folder with the production build.
+This creates a `build/` folder with the production build.
 
-### Deploy the dist folder
+### Deploy the build folder
 
-Upload the contents of `dist/` to your hosting provider:
+Upload the contents of `build/` to your hosting provider:
 
-- **Netlify**: Drag and drop the `dist/` folder to Netlify's deploy interface
-- **GitHub Pages**: Push the `dist/` contents to a `gh-pages` branch
-- **Cloudflare Pages**: Connect your repository and set the build command to `npm run build` with output directory `dist`
-- **AWS S3 + CloudFront**: Upload `dist/` to an S3 bucket and configure CloudFront for CDN delivery
+- **Netlify**: Drag and drop the `build/` folder to Netlify's deploy interface
+- **GitHub Pages**: Push the `build/` contents to a `gh-pages` branch
+- **Cloudflare Pages**: Connect your repository and set the build command to `npm run build` with output directory `build`
+- **AWS S3 + CloudFront**: Upload `build/` to an S3 bucket and configure CloudFront for CDN delivery
 
 ### Environment Variables
 
@@ -106,7 +106,7 @@ Run the test suite with Vitest.
 npm run build
 ```
 
-The optimized production build will be in the `dist/` folder.
+The optimized production build will be in the `build/` folder.
 
 ## Troubleshooting
 

--- a/DEPLOYMENT_EXEDEV.md
+++ b/DEPLOYMENT_EXEDEV.md
@@ -113,8 +113,8 @@ npm run build
 # Install a simple HTTP server
 npm install -g serve
 
-# Serve the dist directory
-serve -s dist -l 3000
+# Serve the build directory
+serve -s build -l 3000
 ```
 
 Accessible at: `https://lightning-decoder.exe.xyz:3000`

--- a/DEPLOYMENT_VERCEL.md
+++ b/DEPLOYMENT_VERCEL.md
@@ -49,7 +49,7 @@ Create a `vercel.json` file in your project root for custom configuration:
 ```json
 {
   "buildCommand": "npm run build",
-  "outputDirectory": "dist",
+  "outputDirectory": "build",
   "devCommand": "npm run dev",
   "installCommand": "npm install"
 }


### PR DESCRIPTION
## Summary
The deployment documentation referenced the default Vite output directory `dist/`, but the project is configured with `build.outDir: "build"` in `vite.config.js`.

## Problem
- **DEPLOYMENT.md**: Static hosting section said the build is in `dist/` and platform instructions used `dist/`
- **DEPLOYMENT_VERCEL.md**: Example `vercel.json` had `"outputDirectory": "dist"`
- **DEPLOYMENT_EXEDEV.md**: Static file server instructions used `dist/`

## Changes
- Updated all `dist/` references to `build/` across DEPLOYMENT.md, DEPLOYMENT_VERCEL.md, and DEPLOYMENT_EXEDEV.md

## Verification
- README was already corrected in PR #143 — this completes the remaining deployment docs
- No application code changes
- Deployment instructions now match the actual Vite configuration