### PR TITLE
chore(deps): remove unused constants COMPLETE_KEY and TAGS_KEY

### DIFF
--- a/src/constants/keys.js
+++ b/src/constants/keys.js
@@ -1,6 +1,5 @@
 // BOLT11 Keys
 export const COIN_TYPE_KEY = 'coinType';
-export const COMPLETE_KEY = 'complete';
 export const PAYEE_NODE_KEY = 'payeeNodeKey';
 export const PAYMENT_REQUEST_KEY = 'paymentRequest';
 export const PREFIX_KEY = 'prefix';
@@ -11,7 +10,6 @@ export const SIGNATURE_KEY = 'signature';
 export const TIMESTAMP_KEY = 'timestamp';
 export const TIMESTAMP_STRING_KEY = 'timestampString';
 export const WORDS_TEMP_KEY = 'wordsTemp';
-export const TAGS_KEY = 'tags';
 export const COMMIT_HASH_KEY = 'purpose_commit_hash';
 export const PAYMENT_HASH_KEY = 'payment_hash';
 export const FALLBACK_ADDRESS_KEY = 'fallback_address';


### PR DESCRIPTION
## Summary
Removes two unused constants from `src/constants/keys.js` that were not imported or referenced anywhere in the codebase.

## Problem
- `COMPLETE_KEY` and `TAGS_KEY` were defined in `src/constants/keys.js` but never imported by any source file
- These were missed in the dead code cleanup from PR #144

## Changes
- Remove `export const COMPLETE_KEY = 'complete';`
- Remove `export const TAGS_KEY = 'tags';`

## Verification
- Grepped entire `src/` tree: no imports of `COMPLETE_KEY` or `TAGS_KEY`
- All 52 tests pass
- `npm run build` completes successfully
- No application behavior changes