### PR TITLE
chore(deps): remove unused direct dependencies (safe-buffer, events, stream-browserify)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,15 +26,12 @@
         "clsx": "^2.1.1",
         "coininfo": "git+https://github.com/cryptocoinjs/coininfo.git#dc3e6cc59e593ee7dbeb7c993485706e72d32743",
         "crypto-browserify": "^3.12.1",
-        "events": "^3.3.0",
         "framer-motion": "^12.40.0",
         "lodash": "^4.17.15",
         "lucide-react": "^1.17.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "safe-buffer": "^5.2.0",
         "secp256k1": "^3.8.1",
-        "stream-browserify": "^3.0.0",
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
@@ -5508,6 +5505,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -7510,6 +7508,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -7951,6 +7950,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
       "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "~2.0.4",
@@ -7974,6 +7974,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"

--- a/package.json
+++ b/package.json
@@ -26,15 +26,12 @@
     "clsx": "^2.1.1",
     "coininfo": "git+https://github.com/cryptocoinjs/coininfo.git#dc3e6cc59e593ee7dbeb7c993485706e72d32743",
     "crypto-browserify": "^3.12.1",
-    "events": "^3.3.0",
     "framer-motion": "^12.40.0",
     "lodash": "^4.17.15",
     "lucide-react": "^1.17.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "safe-buffer": "^5.2.0",
     "secp256k1": "^3.8.1",
-    "stream-browserify": "^3.0.0",
     "tailwind-merge": "^3.6.0"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
Removes three packages from `dependencies` in `package.json` that are not imported anywhere in the source code. They remain available as transitive dependencies via other packages, so behavior is unchanged.

## Packages Removed

| Package | Reason |
|---------|--------|
| `safe-buffer` | Legacy Buffer polyfill. Not directly imported — still installed transitively by `crypto-browserify`, `browserify-sign`, `hash-base`, etc. |
| `events` | Node.js events polyfill. Not directly imported — still installed transitively by `node-stdlib-browser`. |
| `stream-browserify` | Node.js stream polyfill. Not directly imported — still installed transitively by `node-stdlib-browser`. |

## Verification
- [x] All 52 tests pass
- [x] `npm run build` completes successfully
- [x] `npm install` succeeds without warnings
- [x] Grepped `src/` tree — no imports of any of the three packages