### PR TITLE
docs(exe-dev): add missing nodePolyfills plugin to Vite config example

### DIFF
--- a/DEPLOYMENT_EXEDEV.md
+++ b/DEPLOYMENT_EXEDEV.md
@@ -35,21 +35,29 @@ npm install
 
 ### 3. Configure Vite for exe.dev
 
-Update `vite.config.ts` to allow requests from your exe.dev hostname:
+Update `vite.config.js` to allow requests from your exe.dev hostname:
 
-```typescript
+```javascript
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    nodePolyfills({
+      globals: { Buffer: true, global: true, process: true },
+      include: ['buffer', 'crypto', 'events', 'process', 'stream', 'util', 'vm'],
+    }),
+  ],
   server: {
     host: '0.0.0.0',
-    port: 5173,
     allowedHosts: ['lightning-decoder.exe.xyz'],
   },
 });
 ```
+
+> **Note**: The Node.js polyfills plugin is essential — the decoder uses `Buffer`, `crypto`, and other Node.js built-ins internally. Without it, the app will fail at runtime with `Buffer is not defined` errors.
 
 ### 4. Run Development Server
 


### PR DESCRIPTION
## Summary
Fixes the Vite configuration example in DEPLOYMENT_EXEDEV.md that was missing the essential `vite-plugin-node-polyfills` plugin.

## Problem
The Vite config shown in Step 3 of the exe.dev deployment docs omitted the `nodePolyfills` plugin. The decoder critically depends on `Buffer`, `crypto`, `process`, and other Node.js built-ins. Following the documented setup as written would produce a broken app that fails at runtime with `Buffer is not defined` errors.

## Changes
- Add `nodePolyfills` plugin import and configuration matching the actual `vite.config.js`
- Add a callout note explaining why polyfills are essential
- Minor consistency fix: use `.js` extension (matches actual file) instead of `.ts`
- Remove hardcoded `port: 5173` (not required; dev server auto-selects)
- Use `javascript` code block label instead of `typescript` (project uses .js)

## Verification
- Config now matches the project's actual `vite.config.js` structure
- The preview config section (Option 1) correctly uses `// ... existing config` — meaning the fix to Step 3 propagates