### PR TITLE
chore(docker): update .dockerignore to match current build output directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 node_modules
-dist
+build
 .git
 .gitignore
 *.md


### PR DESCRIPTION
## Summary
Updates `.dockerignore` to reference the `build/` directory instead of the stale `dist/` entry.

## Problem
The Vite `build.outDir` was changed from the default `dist/` to `build/` in `vite.config.js`, but `.dockerignore` was not updated. This caused:
- `dist` (stale entry) — no longer a build output, the exclusion was a no-op
- `build` (missing) — the actual build output directory was not excluded from the Docker build context, making it larger than necessary

## Changes
- Replace `dist` with `build` in `.dockerignore`

## Verification
- `.dockerignore` now matches the actual Vite build output directory
- Docker build context will no longer include the unnecessary `build/` directory