### PR TITLE
refactor: replace var with const in internet-identifier validation

### DIFF
--- a/src/utils/internet-identifier.js
+++ b/src/utils/internet-identifier.js
@@ -1,4 +1,4 @@
 export const validateInternetIdentifier = (internetIdentifier) => {
-    var re = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)*\.[^\s@.]+$/;
+    const re = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)*\.[^\s@.]+$/;
     return re.test(internetIdentifier);
 }


### PR DESCRIPTION
## Summary
Replaces the single `var` usage in the codebase with `const` in `src/utils/internet-identifier.js`.

## Problem
The `validateInternetIdentifier` function used the `var` keyword to declare a regular expression that is never reassigned. While `var` works, `const` is the modern JavaScript standard for immutable bindings and aligns with the rest of the codebase (which consistently uses `const`/`let`).

## Changes
- `var re = /^.../` → `const re = /^.../` in `src/utils/internet-identifier.js`

## Verification
- [x] All 52 tests pass
- [x] No functional change — the regex is identical