### PR TITLE
refactor: combine duplicate network error checks in handleLNURL

### DIFF
--- a/src/utils/invoices.js
+++ b/src/utils/invoices.js
@@ -100,10 +100,7 @@ const handleLNURL = (invoice) => {
       return r.json();
     })
     .catch(error => {
-      if (error.message && error.message.includes('NetworkError')) {
-        return Promise.reject(new Error('Network error: Could not reach LNURL service. It may be offline or blocked by CORS.'));
-      }
-      if (error.message && error.message.includes('Failed to fetch')) {
+      if (error.message && (error.message.includes('NetworkError') || error.message.includes('Failed to fetch'))) {
         return Promise.reject(new Error('Network error: Could not reach LNURL service. It may be offline or blocked by CORS.'));
       }
       if (error.message && error.message.includes('JSON')) {


### PR DESCRIPTION
## Summary
Combines two separate conditionals in the `handleLNURL` error handler that produced identical error messages for `NetworkError` and `Failed to fetch`.

## Problem
The catch block in `handleLNURL` had two adjacent `if` statements that checked for `NetworkError` and `Failed to fetch` respectively, each returning the exact same error message. This duplicated logic reduces readability and maintainability.

## Changes
- Combined the two checks into a single `if` statement using `||`
- No behavior change — the same error message is produced for both conditions

## Verification
- [x] All 52 tests pass
- [x] No functional change