### PR TITLE
chore(vite): remove stale development hostname from allowedHosts

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,6 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills';
 export default defineConfig({
   server: {
     host: '0.0.0.0',
-    allowedHosts: ['hermes-an.exe.xyz'],
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
Removes the hardcoded `allowedHosts: ["hermes-an.exe.xyz"]` from `vite.config.js` that was a development-specific hostname left in the public configuration.

## Problem
The `allowedHosts` option in the Vite dev server was set to a specific developer's test VM hostname (`hermes-an.exe.xyz`). This does not belong in the public repository:
- It is specific to one person's testing environment
- It has no effect on production builds
- Anyone who needs `allowedHosts` for their own deployment can add it locally

## Changes
- Remove `allowedHosts: ["hermes-an.exe.xyz"]` from the Vite dev server config
- Keep `host: "0.0.0.0"` which is intentional for Docker/dev container support

## Verification
- [x] `npm run build` completes successfully
- [x] No application behavior changes
- [x] Dev server still works with `host: "0.0.0.0"`
- [x] Production builds are unaffected