### PR TITLE
docs(deployment): replace deprecated docker scan with docker scout

### DIFF
--- a/DEPLOYMENT_DOCKER.md
+++ b/DEPLOYMENT_DOCKER.md
@@ -203,8 +203,10 @@ USER appuser
 2. **Scan for vulnerabilities**:
 
 ```bash
-docker scan lightning-decoder
+docker scout quickview lightning-decoder
 ```
+
+> **Note**: `docker scan` has been replaced by `docker scout`. If you have an older Docker version, upgrade or visit [docker scout docs](https://docs.docker.com/scout/) for alternative installation instructions.
 
 3. **Use specific image tags**:
 


### PR DESCRIPTION
## Summary
Replaces the deprecated `docker scan` command in DEPLOYMENT_DOCKER.md with the current recommended `docker scout quickview` command.

## Problem
The "Scan for vulnerabilities" section of the Docker deployment docs referenced `docker scan lightning-decoder`, but `docker scan` has been deprecated by Docker. The replacement is `docker scout` which provides enhanced vulnerability scanning capabilities.

## Changes
- Replace `docker scan lightning-decoder` with `docker scout quickview lightning-decoder`
- Add a callout note explaining the deprecation and linking to Docker Scout docs

## Verification
- [x] No application code changes
- [x] Documentation now reflects current Docker CLI tooling