### PR TITLE
fix(docker): correct COPY path from dist to build in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN npm run build
 FROM nginx:alpine
 
 # Copy built assets from builder
-COPY --from=builder /app/dist /usr/share/nginx/html
+COPY --from=builder /app/build /usr/share/nginx/html
 
 # Copy nginx configuration
 COPY nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Summary
The Vite config sets `outDir: 'build'`, but the Dockerfile was copying from `/app/dist` which does not exist inside the builder container. This would cause Docker builds to fail at the COPY step.

## Problem
- `npm run build` (via Vite) outputs to `/app/build/` (per `vite.config.js`)
- The Dockerfile's COPY command references `/app/dist`, which is never created
- This makes the Docker image serve nothing (or fails entirely if `dist` is absent)

## Changes
- Fix `COPY --from=builder /app/dist ...` → `COPY --from=builder /app/build ...`

## Verification
- PR #158 previously fixed `.dockerignore` for the same `dist → build` issue, but the Dockerfile's COPY command was missed
- Vite config confirms `outDir: 'build'`
- No other references to `/app/dist` remain in the Dockerfile