### PR TITLE
chore(deps): remove redundant autoprefixer PostCSS plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@storybook/test": "^8.6.18",
     "@tailwindcss/postcss": "^4.3.0",
     "@vitejs/plugin-react": "^4.3.4",
-    "autoprefixer": "^10.5.0",
     "jsdom": "^29.1.1",
     "postcss": "^8.5.15",
     "storybook": "^8.6.18",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,9 +1,7 @@
 import tailwindcss from '@tailwindcss/postcss';
-import autoprefixer from 'autoprefixer';
 
 export default {
   plugins: [
     tailwindcss,
-    autoprefixer,
   ],
 };


### PR DESCRIPTION
## Summary
Tailwind CSS v4's `@tailwindcss/postcss` plugin uses Lightning CSS internally, which handles vendor prefixing automatically. The separate `autoprefixer` PostCSS plugin and its devDependency are unnecessary.

## Problem
- Tailwind v4 with `@tailwindcss/postcss` already includes Lightning CSS which adds vendor prefixes
- The standalone `autoprefixer` PostCSS plugin is redundant
- It adds an unnecessary dependency and build step

## Changes
- Remove `autoprefixer` import and plugin from `postcss.config.js`
- Remove `autoprefixer` from `package.json` devDependencies

## Verification
- [x] All 52 tests pass
- [x] `npm run build` completes successfully
- [x] CSS vendor prefixes are still applied (Lightning CSS handles this)