### PR TITLE
chore: remove stale ga.js reference from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,6 @@
 /.pnp
 .pnp.js
 
-# keys
-ga.js
-
 # testing
 /coverage
 


### PR DESCRIPTION
## Summary
The `.gitignore` file contained a `# keys` section with a reference to `ga.js`, but this file does not exist in the repository. This is stale configuration with no effect.

## Problem
- `ga.js` was listed under a `# keys` comment in `.gitignore`
- The file has never existed in the repository's history
- The entry was a no-op and the comment section was misleading

## Changes
- Remove `# keys` comment header
- Remove `ga.js` entry
- Remove the blank line that separated this section from the next

## Verification
- PR #156 is removing `.npmignore` which also referenced `ga.js` (via `!ga.js`)
- This change completes the cleanup by also removing the stale `.gitignore` entry