### PR TITLE
docs: fix stale dist/ references to build/ in deployment documentation

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -58,16 +58,16 @@ Since Lightning Decoder is a static site built with Vite, it can be deployed to 
 npm run build
 ```
 
-This creates a `dist/` folder with the production build.
+This creates a `build/` folder with the production build.
 
-### Deploy the dist folder
+### Deploy the build folder
 
-Upload the contents of `dist/` to your hosting provider:
+Upload the contents of `build/` to your hosting provider:
 
-- **Netlify**: Drag and drop the `dist/` folder to Netlify's deploy interface
-- **GitHub Pages**: Push the `dist/` contents to a `gh-pages` branch
-- **Cloudflare Pages**: Connect your repository and set the build command to `npm run build` with output directory `dist`
-- **AWS S3 + CloudFront**: Upload `dist/` to an S3 bucket and configure CloudFront for CDN delivery
+- **Netlify**: Drag and drop the `build/` folder to Netlify's deploy interface
+- **GitHub Pages**: Push the `build/` contents to a `gh-pages` branch
+- **Cloudflare Pages**: Connect your repository and set the build command to `npm run build` with output directory `build`
+- **AWS S3 + CloudFront**: Upload `build/` to an S3 bucket and configure CloudFront for CDN delivery
 
 ### Environment Variables
 
@@ -106,7 +106,7 @@ Run the test suite with Vitest.
 npm run build
 ```
 
-The optimized production build will be in the `dist/` folder.
+The optimized production build will be in the `build/` folder.
 
 ## Troubleshooting
 

--- a/DEPLOYMENT_EXEDEV.md
+++ b/DEPLOYMENT_EXEDEV.md
@@ -113,8 +113,8 @@ npm run build
 # Install a simple HTTP server
 npm install -g serve
 
-# Serve the dist directory
-serve -s dist -l 3000
+# Serve the build directory
+serve -s build -l 3000
 ```
 
 Accessible at: `https://lightning-decoder.exe.xyz:3000`

--- a/DEPLOYMENT_VERCEL.md
+++ b/DEPLOYMENT_VERCEL.md
@@ -49,7 +49,7 @@ Create a `vercel.json` file in your project root for custom configuration:
 ```json
 {
   "buildCommand": "npm run build",
-  "outputDirectory": "dist",
+  "outputDirectory": "build",
   "devCommand": "npm run dev",
   "installCommand": "npm install"
 }


### PR DESCRIPTION
## Summary
Vite is configured with `outDir: 'build'` in `vite.config.js`, but the deployment documentation still referenced `dist/` in multiple places. This updates all stale references.

## Problem
- `npm run build` outputs to `build/`, not `dist/`
- DEPLOYMENT.md had 8 stale `dist/` references (build output description, deploy guide, hosting provider instructions, troubleshooting section)
- DEPLOYMENT_VERCEL.md had a `vercel.json` example with `"outputDirectory": "dist"`
- DEPLOYMENT_EXEDEV.md had `serve -s dist` instead of `serve -s build`

## Changes
- **DEPLOYMENT.md**: Updated all 8 references from `dist/` to `build/`
- **DEPLOYMENT_VERCEL.md**: Updated `vercel.json` example to use `"outputDirectory": "build"`
- **DEPLOYMENT_EXEDEV.md**: Updated serve command from `serve -s dist` to `serve -s build`

## Verification
- `npm run build` outputs to `build/` (confirmed by build output above)
- `vercel.json` already correctly uses `"outputDirectory": "build"`
- Only documentation files were changed — no code or configuration behavior modified

Closes #(issue)