### PR TITLE
fix(nginx): add Content-Security-Policy security header

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -19,4 +19,5 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' http: https:; frame-ancestors 'none'; form-action 'self'; base-uri 'self'" always;
 }


### PR DESCRIPTION
## Summary
Adds a Content-Security-Policy header to the nginx configuration to complement the existing security headers (X-Frame-Options, X-Content-Type-Options, X-XSS-Protection, Referrer-Policy).

## Problem
- The nginx.conf had security headers but was missing Content-Security-Policy
- CSP is a critical defense-in-depth layer that mitigates XSS and data injection attacks
- Without CSP, inline scripts and unauthorized resource loads cannot be restricted

## Policy
The CSP allows the app to function fully while providing meaningful restrictions:

| Directive | Value | Rationale |
|-----------|-------|-----------|
| default-src | 'self' | Restrict all resources to same-origin by default |
| script-src | 'self' 'unsafe-inline' | Allow app scripts and Vite/React inline handlers |
| style-src | 'self' 'unsafe-inline' | Allow bundled and inline styles |
| img-src | 'self' data: blob: | Allow images from self and data URIs |
| font-src | 'self' | Restrict fonts (Geist Mono from @fontsource) |
| connect-src | 'self' http: https: | Allow LNURL/Lightning Address resolution |
| frame-ancestors | 'none' | Clickjacking protection (augments X-Frame-Options) |
| form-action | 'self' | Restrict form submissions |
| base-uri | 'self' | Prevent base tag injection |

## Verification
- The CSP is permissive enough for the app to function (inline scripts, external HTTP connections for LN resolution, bundled assets)
- No application code changes were needed
- The header is set with the `always` flag so it applies to all response types including error pages