### PR TITLE
docs(exedev): fix vite.config.ts to vite.config.js in deployment guide

### DIFF
--- a/DEPLOYMENT_EXEDEV.md
+++ b/DEPLOYMENT_EXEDEV.md
@@ -35,7 +35,7 @@ npm install
 
 ### 3. Configure Vite for exe.dev
 
-Update `vite.config.ts` to allow requests from your exe.dev hostname:
+Update `vite.config.js` to allow requests from your exe.dev hostname:
 
 ```typescript
 import { defineConfig } from 'vite';
@@ -69,7 +69,7 @@ For production, build and serve the static files:
 # Build the app
 npm run build
 
-# Update vite.config.ts for preview server
+# Update vite.config.js for preview server
 # Add preview configuration:
 ```
 
@@ -269,7 +269,7 @@ netstat -tlnp | grep -E '5173|4173|80|3000'
 
 ### "Host not allowed" Error
 
-If you see this error, update `vite.config.ts`:
+If you see this error, update `vite.config.js`:
 
 ```typescript
 server: {


### PR DESCRIPTION
## Summary
The exe.dev deployment guide referenced `vite.config.ts` in three places, but the project uses `vite.config.js`. This fixes all references to match the actual file name.

## Problem
- Users following the exe.dev deployment guide would try to find/edit `vite.config.ts`, which does not exist
- The actual configuration file is `vite.config.js`

## Changes
- Line 38: `Update vite.config.ts to allow requests...` → `vite.config.js`
- Line 72: `# Update vite.config.ts for preview server` → `vite.config.js`
- Line 272: `If you see this error, update vite.config.ts:` → `vite.config.js`

## Verification
- Only documentation was changed — no code or configuration behavior modified
- The actual config file is confirmed to be `vite.config.js`