### PR TITLE
docs: replace deprecated docker-compose v1 commands with docker compose v2

### DIFF
--- a/DEPLOYMENT_DOCKER.md
+++ b/DEPLOYMENT_DOCKER.md
@@ -41,13 +41,13 @@ services:
 Run with:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 Stop with:
 
 ```bash
-docker-compose down
+docker compose down
 ```
 
 ## Production Deployment

--- a/DEPLOYMENT_EXEDEV.md
+++ b/DEPLOYMENT_EXEDEV.md
@@ -97,7 +97,7 @@ If you have Docker installed on your VM:
 
 ```bash
 # Build and run with Docker Compose
-docker-compose up -d
+docker compose up -d
 
 # The app will be available on port 80
 ```
@@ -234,7 +234,7 @@ npm run build
 pm2 restart lightning-decoder
 
 # Or restart Docker
-docker-compose restart
+docker compose restart
 ```
 
 ## Monitoring
@@ -246,7 +246,7 @@ docker-compose restart
 pm2 logs lightning-decoder
 
 # Docker logs
-docker-compose logs -f
+docker compose logs -f
 
 # System logs
 journalctl -u lightning-decoder
@@ -259,7 +259,7 @@ journalctl -u lightning-decoder
 pm2 status
 
 # Docker status
-docker-compose ps
+docker compose ps
 
 # Port availability
 netstat -tlnp | grep -E '5173|4173|80|3000'


### PR DESCRIPTION
## Summary
Docker Compose v1 (`docker-compose` Python CLI) was deprecated in July 2023. The modern v2 plugin (`docker compose`, built into Docker CLI) is now the standard. This updates all command examples in deployment documentation.

## Problem
- DEPLOYMENT_DOCKER.md and DEPLOYMENT_EXEDEV.md still used the deprecated `docker-compose` v1 command
- Users following these guides on newer Docker installations would get `docker-compose: command not found`
- The v2 `docker compose` subcommand has been the recommended replacement since Docker Desktop 4.22+

## Changes

### DEPLOYMENT_DOCKER.md
- `docker-compose up -d` → `docker compose up -d`
- `docker-compose down` → `docker compose down`

### DEPLOYMENT_EXEDEV.md
- `docker-compose up -d` → `docker compose up -d` (Docker section)
- `docker-compose restart` → `docker compose restart`
- `docker-compose logs -f` → `docker compose logs -f`
- `docker-compose ps` → `docker compose ps`

## Verification
- Only command invocations were changed — filename references to `docker-compose.yml` are left unchanged since both v1 and v2 Compose accept it as the default compose file
- No behavioral changes — the v2 plugin is a drop-in replacement for all commands used here