### PR TITLE
docs(docker): update stale GitHub Actions versions in CI/CD example

### DIFF
--- a/DEPLOYMENT_DOCKER.md
+++ b/DEPLOYMENT_DOCKER.md
@@ -230,19 +230,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           push: true
           tags: yourusername/lightning-decoder:latest


### PR DESCRIPTION
## Summary
The CI/CD example in DEPLOYMENT_DOCKER.md referenced outdated GitHub Action versions. This updates them to current releases.

## Problem
- `actions/checkout@v3` — v4 is the current stable release
- `docker/setup-buildx-action@v2` — v3 is the current stable release
- `docker/login-action@v2` — v3 is the current stable release
- `docker/build-push-action@v4` — v6 is the current stable release

Users copying this example would get deprecation warnings from GitHub Actions and miss out on performance improvements in newer versions.

## Changes
| Before | After |
|--------|-------|
| actions/checkout@v3 | actions/checkout@v4 |
| docker/setup-buildx-action@v2 | docker/setup-buildx-action@v3 |
| docker/login-action@v2 | docker/login-action@v3 |
| docker/build-push-action@v4 | docker/build-push-action@v6 |

## Verification
- Only the version tags in the example YAML were changed — no behavioral or structural modifications
- The actual CI workflow (`.github/workflows/ci.yml`) already uses `actions/checkout@v4` and `actions/setup-node@v4`