### PR TITLE
fix(manifest): correct favicon reference from non-existent .ico to .png

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,9 +3,9 @@
   "name": "Lightning Decoder",
   "icons": [
     {
-      "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
+      "src": "favicon.png",
+      "sizes": "32x32",
+      "type": "image/png"
     }
   ],
   "start_url": ".",


### PR DESCRIPTION
## Summary
The web app manifest referenced `favicon.ico` with type `image/x-icon`, but no `favicon.ico` file exists in the repository. The actual favicon file is `public/favicon.png`.

## Problem
- `public/manifest.json` had `"src": "favicon.ico"` with `"type": "image/x-icon"`
- Only `public/favicon.png` exists — no `.ico` version is available
- Browsers loading the manifest would attempt to fetch a non-existent file, resulting in a 404

## Changes
| Field | Before | After |
|-------|--------|-------|
| src | favicon.ico | favicon.png |
| type | image/x-icon | image/png |
| sizes | 64x64 32x32 24x24 16x16 (multi-res .ico list) | 32x32 (single PNG size) |

## Verification
- The actual favicon file `public/favicon.png` is confirmed to exist (32x32 PNG)
- The `index.html` already correctly references `<link rel="shortcut icon" type="image/png" href="/favicon.png">`
- No behavior change — the correct icon file will now be served from the manifest