### PR TITLE
chore: remove unused X icon import from alert component

### DIFF
--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,7 +1,5 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
-import { X } from "lucide-react"
-
 import { cn } from "../../lib/utils"
 
 const alertVariants = cva(


### PR DESCRIPTION
## Summary
Removes an unused import in the Alert UI component. The `X` icon from `lucide-react` was imported but never referenced in the component.

## Problem
- `src/components/ui/alert.tsx` imported `{ X }` from `lucide-react`
- The `X` icon was never used in the component — no close button or any other use of `X`
- This was left over from the shadcn/ui template which typically includes a close button

## Changes
- Remove `import { X } from "lucide-react"` from `alert.tsx`

## Verification
- [x] All 52 tests pass
- [x] `npm run build` succeeds
- [x] `X` is not referenced anywhere else in the file
- [x] No behavioral changes — the Alert component continues to function identically