### PR TITLE
docs(docker): remove deprecated version field from docker-compose examples

### DIFF
--- a/DEPLOYMENT_DOCKER.md
+++ b/DEPLOYMENT_DOCKER.md
@@ -28,8 +28,6 @@ The application will be available at `http://localhost:8080`
 For easier management, create a `docker-compose.yml`:
 
 ```yaml
-version: '3.8'
-
 services:
   lightning-decoder:
     build: .
@@ -57,8 +55,6 @@ docker-compose down
 Use a reverse proxy like nginx or Traefik to handle SSL:
 
 ```yaml
-version: '3.8'
-
 services:
   lightning-decoder:
     build: .


### PR DESCRIPTION
## Summary
Removes the deprecated `version` field from docker-compose configuration examples in deployment documentation.

## Problem
- Both docker-compose examples in DEPLOYMENT_DOCKER.md included `version: '3.8'`
- The `version` field is deprecated in Docker Compose v2 (the current standard)
- Docker Compose v2 ignores the field entirely and warns: `WARN[0000] ./docker-compose.yml: \`version\` is obsolete`
- PR #170 already updates the `docker-compose` command invocations to `docker compose`, but the compose file content still had the deprecated field

## Changes
| Example | Before | After |
|---------|--------|-------|
| Basic compose (line 28) | `version: '3.8'` + services | services only |
| SSL reverse proxy (line 55) | `version: '3.8'` + services | services only |

## Verification
- The `version` field is purely cosmetic in Docker Compose v2+ — removing it causes no behavioral change
- The docker-compose examples remain valid and functional
- No other files were modified