### PR TITLE
chore: remove unused CardFooter export from card component

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -64,16 +64,4 @@ const CardContent = React.forwardRef<
 ))
 CardContent.displayName = "CardContent"
 
-const CardFooter = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
-    {...props}
-  />
-))
-CardFooter.displayName = "CardFooter"
-
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+export { Card, CardHeader, CardTitle, CardDescription, CardContent }


### PR DESCRIPTION
## Summary
Removes the unused `CardFooter` export from the card UI component. It was defined and exported but never imported or used anywhere in the codebase.

## Problem
- `CardFooter` was defined as a forwarded-ref component in `src/components/ui/card.tsx`
- It was exported but never imported by any source file, test file, or story file
- The only usage in `payment-hash-verifier.tsx` imports `Card, CardContent, CardDescription, CardHeader, CardTitle` — no `CardFooter`

## Changes
- Remove `CardFooter` component definition and its `displayName` assignment
- Remove `CardFooter` from the export list

## Verification
- [x] All 52 tests pass
- [x] `npm run build` succeeds
- [x] `CardFooter` is not referenced anywhere else in the codebase
- [x] No behavioral changes — the Card component family continues to function identically