### PR TITLE
chore: remove unused SheetFooter and SheetClose exports from sheet component

### DIFF
--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -9,8 +9,6 @@ const Sheet = SheetPrimitive.Root
 
 const SheetTrigger = SheetPrimitive.Trigger
 
-const SheetClose = SheetPrimitive.Close
-
 const SheetPortal = SheetPrimitive.Portal
 
 const SheetOverlay = React.forwardRef<
@@ -88,20 +86,6 @@ const SheetHeader = ({
 )
 SheetHeader.displayName = "SheetHeader"
 
-const SheetFooter = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
-    )}
-    {...props}
-  />
-)
-SheetFooter.displayName = "SheetFooter"
-
 const SheetTitle = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
@@ -131,9 +115,7 @@ export {
   SheetPortal,
   SheetOverlay,
   SheetTrigger,
-  SheetClose,
   SheetContent,
-  SheetFooter,
   SheetHeader,
   SheetTitle,
   SheetDescription,


### PR DESCRIPTION
## Summary
Removes the unused `SheetFooter` and `SheetClose` exports from the sheet UI component. Both were defined and exported but never imported or used anywhere in the codebase.

## Problem
- `SheetClose` was an alias (`const SheetClose = SheetPrimitive.Close`) that was never imported by any file
- `SheetFooter` was a forwarded-ref layout component that was never imported by any file
- The header and invoice-details components import `Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger` — none of them use `SheetClose` or `SheetFooter`
- The close button in `SheetContent` already uses `SheetPrimitive.Close` directly (not the re-exported `SheetClose`)

## Changes
- Remove `const SheetClose = SheetPrimitive.Close`
- Remove `SheetFooter` component definition and its `displayName` assignment
- Remove both from the export list

## Verification
- [x] All 52 tests pass
- [x] `npm run build` succeeds
- [x] Neither `SheetClose` nor `SheetFooter` is referenced anywhere else in the codebase
- [x] No behavioral changes — the Sheet component family continues to function identically