### PR TITLE
fix(nginx): add Strict-Transport-Security header for HTTPS deployments

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -19,4 +19,5 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 }


### PR DESCRIPTION
## Summary

Adds the `Strict-Transport-Security` (HSTS) header to the nginx configuration to enforce HTTPS connections in production deployments.

## Changes

- **nginx.conf**: Added `add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;` to the security headers block

## Why

The nginx config already sets several security headers (`X-Frame-Options`, `X-Content-Type-Options`, `X-XSS-Protection`, `Referrer-Policy`) but was missing HSTS. This header tells browsers to always connect via HTTPS after the first visit, helping protect against protocol downgrade attacks and cookie hijacking.

## Impact

- Adds a 1-year (31536000s) max-age with `includeSubDomains`
- Safe for the existing Docker deployment pattern (TLS termination at reverse proxy)
- No behavior change for development/localhost usage (browsers ignore HSTS on localhost)

## Test Plan

- [x] nginx config syntax is valid (no syntax errors in the one-line addition)
- [x] Existing Docker deployment continues to work unchanged
- [x] Build passes