### PR TITLE
chore: remove unused DialogFooter export from dialog component

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -65,20 +65,6 @@ const DialogHeader = ({
 )
 DialogHeader.displayName = "DialogHeader"
 
-const DialogFooter = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
-    )}
-    {...props}
-  />
-)
-DialogFooter.displayName = "DialogFooter"
-
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
@@ -114,7 +100,6 @@ export {
   DialogTrigger,
   DialogContent,
   DialogHeader,
-  DialogFooter,
   DialogTitle,
   DialogDescription,
 }


### PR DESCRIPTION
## Summary

Removes the unused `DialogFooter` export from `src/components/ui/dialog.tsx`, following the same cleanup pattern as PR #175 (CardFooter) and PR #176 (SheetFooter).

## Why

`DialogFooter` was defined and exported but never imported or used anywhere in the application. Removing unused exports reduces bundle size slightly and keeps the component API clean.

## Changes

- **`src/components/ui/dialog.tsx`**: Removed `DialogFooter` component definition, `displayName`, and export

## Test Plan

- [x] All 52 existing tests pass
- [x] Production build completes successfully
- [x] The component is not imported or referenced anywhere else in the codebase